### PR TITLE
MES-995: Add preTest + waitingRoom to the cat B schema

### DIFF
--- a/mes-test-schema/categories/schema-category-B.json
+++ b/mes-test-schema/categories/schema-category-B.json
@@ -4,11 +4,41 @@
   "definitions": {
     "faults": {
       "type": "object"
+    },
+    "waitingRoom": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "insuranceDeclarationAccepted": {
+          "description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
+          "type": "boolean"
+        },
+        "residencyDeclarationAccepted": {
+          "description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
+          "type": "boolean"
+        },
+        "signature": {
+          "description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+          "type": "string"
+        }
+      },
+      "required": ["insuranceDeclarationAccepted", "residencyDeclarationAccepted", "signature"]
+    },
+    "preTest": {
+      "type": "object",
+      "description": "Data related to the test phase prior to the test report",
+      "additionalProperties": false,
+      "required": ["waitingRoom"],
+      "properties": {
+        "waitingRoom": {
+          "$ref": "#/definitions/waitingRoom"
+        }
+      }
     }
   },
   "properties": {
     "category": {
-      "description": "Category code for the test",
+      "description": "Category code for the test report",
       "type": "string"
     },
     "id": {
@@ -33,8 +63,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "preTest": {
+      "$ref": "#/definitions/preTest"
     }
   },
   "additionalProperties": false,
-  "required": ["category", "id"]
+  "required": ["category", "id", "preTest"]
 }

--- a/mes-test-schema/categories/schema-category-B.json
+++ b/mes-test-schema/categories/schema-category-B.json
@@ -5,6 +5,17 @@
     "faults": {
       "type": "object"
     },
+    "testData": {
+      "description": "Data associated with the test",
+      "type": "object",
+      "properties": {
+        "faults": {
+          "description": "Details of any faults recorded",
+          "$ref": "#/definitions/faults"
+        }
+      },
+      "additionalProperties": false
+    },
     "waitingRoom": {
       "type": "object",
       "additionalProperties": false,
@@ -54,20 +65,12 @@
       "type": "string"
     },
     "testData": {
-      "description": "Data associated with the test",
-      "type": "object",
-      "properties": {
-        "faults": {
-          "description": "Details of any faults recorded",
-          "$ref": "#/definitions/faults"
-        }
-      },
-      "additionalProperties": false
+      "$ref": "#/definitions/testData"
     },
     "preTest": {
       "$ref": "#/definitions/preTest"
     }
   },
   "additionalProperties": false,
-  "required": ["category", "id", "preTest"]
+  "required": ["category", "id", "testData", "preTest"]
 }


### PR DESCRIPTION
* Ensure that we publish the cat B types to npm via `.npmignore`
* Extract type for `TestData`
* Generate the following new interfaces:
```
/**
 * Data related to the test phase prior to the test report
 */
export interface PreTest {
  waitingRoom: WaitingRoom;
}
export interface WaitingRoom {
  /**
   * Whether or not the candidate has declared that their test vehicle has a valid insurance policy
   */
  insuranceDeclarationAccepted: boolean;
  /**
   * Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test
   */
  residencyDeclarationAccepted: boolean;
  /**
   * Base 64 encoded binary data representing a PNG image of the candidates signature
   */
  signature: string;
}
```