### PR TITLE
Publish test schema v1.0.4

### DIFF
--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -243,8 +243,8 @@ export interface VehicleDetails {
   /**
    * The vehicle registration number
    */
-  registrationNumber: string;
-  gearboxCategory: GearboxCategory;
+  registrationNumber?: string;
+  gearboxCategory?: GearboxCategory;
   /**
    * Indicates whether the vehicle belongs to a driving school
    */
@@ -281,9 +281,9 @@ export interface TestData {
  * Details of the Show Me and Tell Me questions asked during the test
  */
 export interface VehicleChecks {
-  tellMeQuestionCode: QuestionCode;
-  tellMeQuestionDescription: QuestionDescription;
-  tellMeQuestionOutcome: QuestionOutcome;
+  tellMeQuestionCode?: QuestionCode;
+  tellMeQuestionDescription?: QuestionDescription;
+  tellMeQuestionOutcome?: QuestionOutcome;
   showMeQuestionCode?: QuestionCode;
   showMeQuestionDescription?: QuestionDescription;
   showMeQuestionOutcome?: QuestionOutcome;

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
* Generate TypeScript definitions missed in previous check-in
* Complete cat B full journey, including post-test
* Refactor how faults and other test related data is stored
* Removed mandatory restrictions on several items to accommodate terminations
* Extract additional types for usage in the mobile app