### PR TITLE
Add Journal Data to Test Schema

### DIFF
--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -121,6 +121,10 @@ export interface JournalData {
    */
   welshTest: boolean;
   /**
+   * Whether the candidate has any special needs that require the D255 form to be completed
+   */
+  specialNeeds?: boolean;
+  /**
    * Whether this is an extended test
    */
   extendedTest: boolean;

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -6,10 +6,6 @@
  */
 
 /**
- * Whether the test is to be conducted using the welsh language
- */
-export type WelshTest = boolean;
-/**
  * Base 64 encoded binary data representing a PNG image of the candidates signature
  */
 export type Signature = string;
@@ -69,7 +65,6 @@ export type WeatherConditions =
   | "Windy";
 
 export interface StandardCarTestCATBSchema {
-  welshTest: WelshTest;
   /**
    * Category code for the test report
    */
@@ -78,16 +73,11 @@ export interface StandardCarTestCATBSchema {
    * Unique identifier for the test
    */
   id: string;
-  /**
-   * Unique identifier for the journal test slot
-   */
-  slotId: number;
+  journalData: JournalData;
   /**
    * Code representing the result of the test
    */
   activityCode: string;
-  candidate: Candidate;
-  applicationReference: ApplicationReference;
   preTestDeclarations?: PreTestDeclarations;
   eyesightTestResult?: EyesightTestResult;
   accompaniment?: Accompaniment;
@@ -99,6 +89,45 @@ export interface StandardCarTestCATBSchema {
   testSummary?: TestSummary;
 }
 /**
+ * Data brought through from the journal
+ */
+export interface JournalData {
+  /**
+   * The examiner's DSA staff number
+   */
+  staffNumber: string;
+  /**
+   * Cost centre code for the test centre
+   */
+  costCode: string;
+  /**
+   * Unique identifier for the journal test slot
+   */
+  slotId: number;
+  /**
+   * Start time of the test slot
+   */
+  start: string;
+  /**
+   * The test category reference
+   */
+  testCategory: string;
+  /**
+   * A short description of the Vehicle Slot Type, e.g. B57mins, Voc90mins, Hometest
+   */
+  vehicleSlotType: string;
+  /**
+   * Whether the test is to be conducted using the welsh language
+   */
+  welshTest: boolean;
+  /**
+   * Whether this is an extended test
+   */
+  extendedTest: boolean;
+  candidate: Candidate;
+  applicationReference: ApplicationReference;
+}
+/**
  * Details of the candidate booked into the test slot
  */
 export interface Candidate {
@@ -108,7 +137,7 @@ export interface Candidate {
   candidateId?: number;
   candidateName?: Name;
   /**
-   * The candidate's driver number if any, typically (though not always) 16 characters if UK, or 8 digits if NI
+   * The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI
    */
   driverNumber?: string;
   candidateAddress?: Address;

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -2,10 +2,6 @@
   "title": "Standard Car Test (CAT B) Schema",
   "type": "object",
   "definitions": {
-    "welshTest": {
-      "description": "Whether the test is to be conducted using the welsh language",
-      "type": "boolean"
-    },
     "name": {
       "description": "Details of the individual's name",
       "type": "object",
@@ -87,7 +83,7 @@
           "$ref": "#/definitions/name"
         },
         "driverNumber": {
-          "description": "The candidate's driver number if any, typically (though not always) 16 characters if UK, or 8 digits if NI",
+          "description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
           "type": "string",
           "maxLength": 24
         },
@@ -147,6 +143,69 @@
         "applicationId",
         "bookingSequence",
         "checkDigit"
+      ]
+    },
+    "journalData": {
+      "description": "Data brought through from the journal",
+      "type": "object",
+      "properties": {
+        "staffNumber": {
+          "description": "The examiner's DSA staff number",
+          "type": "string",
+          "maxLength": 10
+        },
+        "costCode": {
+          "description": "Cost centre code for the test centre",
+          "type": "string",
+          "maxLength": 6
+        },
+        "slotId": {
+          "description": "Unique identifier for the journal test slot",
+          "type": "integer"
+        },
+        "start": {
+          "description": "Start time of the test slot",
+          "type": "string",
+          "minLength": 25,
+          "maxLength": 25
+        },
+        "testCategory": {
+          "description": "The test category reference",
+          "type": "string",
+          "maxLength": 10
+        },
+        "vehicleSlotType": {
+          "description": "A short description of the Vehicle Slot Type, e.g. B57mins, Voc90mins, Hometest",
+          "type": "string",
+          "maxLength": 11
+        },
+        "welshTest": {
+          "description": "Whether the test is to be conducted using the welsh language",
+          "type": "boolean"
+        },
+        "extendedTest": {
+          "description": "Whether this is an extended test",
+          "type": "boolean"
+        },
+        "candidate": {
+          "$ref": "#/definitions/candidate"
+        },
+        "applicationReference": {
+          "$ref": "#/definitions/applicationReference"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "staffNumber",
+        "costCode",
+        "slotId",
+        "start",
+        "testCategory",
+        "vehicleSlotType",
+        "welshTest",
+        "extendedTest",
+        "candidate",
+        "applicationReference"
       ]
     },
     "signature": {
@@ -953,9 +1012,6 @@
     }
   },
   "properties": {
-    "welshTest": {
-      "$ref": "#/definitions/welshTest"
-    },
     "category": {
       "description": "Category code for the test report",
       "type": "string"
@@ -964,19 +1020,12 @@
       "description": "Unique identifier for the test",
       "type": "string"
     },
-    "slotId": {
-      "description": "Unique identifier for the journal test slot",
-      "type": "integer"
+    "journalData": {
+      "$ref": "#/definitions/journalData"
     },
     "activityCode": {
       "description": "Code representing the result of the test",
       "type": "string"
-    },
-    "candidate": {
-      "$ref": "#/definitions/candidate"
-    },
-    "applicationReference": {
-      "$ref": "#/definitions/applicationReference"
     },
     "preTestDeclarations": {
       "$ref": "#/definitions/preTestDeclarations"
@@ -1008,12 +1057,9 @@
   },
   "additionalProperties": false,
   "required": [
-    "welshTest",
     "category",
     "id",
-    "slotId",
-    "activityCode",
-    "candidate",
-    "applicationReference"
+    "journalData",
+    "activityCode"
   ]
 }

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -183,6 +183,10 @@
           "description": "Whether the test is to be conducted using the welsh language",
           "type": "boolean"
         },
+        "specialNeeds": {
+          "description": "Whether the candidate has any special needs that require the D255 form to be completed",
+          "type": "boolean"
+        },
         "extendedTest": {
           "description": "Whether this is an extended test",
           "type": "boolean"

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -207,6 +207,7 @@
         "testCategory",
         "vehicleSlotType",
         "welshTest",
+        "specialNeeds",
         "extendedTest",
         "candidate",
         "applicationReference"

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
Certain data items that are stored in the journal schema need to be brought through to the test schema so that they can be stored for use later in the app and can be included in TARS interface feeds.