### PR TITLE
MES-2168: Test schema - refactor manoeuvres

### DIFF
--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -54,6 +54,14 @@ export type SeriousFaultIndicator = boolean;
  */
 export type DangerousFaultIndicator = boolean;
 /**
+ * Method chosen to conduct the independent driving section of the test
+ */
+export type IndependentDriving = "Sat nav" | "Traffic signs";
+/**
+ * Indicates which form of ID was provided by the candidate
+ */
+export type Identification = "Licence" | "Passport";
+/**
  * Predefined values for the type of weather encountered during the test
  */
 export type WeatherConditions =
@@ -711,10 +719,7 @@ export interface TestSummary {
    * Number of the route that was taken during the test
    */
   routeNumber?: number;
-  /**
-   * Method chosen to conduct the independent driving section of the test
-   */
-  independentDriving?: "Sat nav" | "Traffic signs";
+  independentDriving?: IndependentDriving;
   /**
    * Physical description of the candidate
    */
@@ -723,10 +728,7 @@ export interface TestSummary {
    * Indicates whether anybody else (e.g. ADI) was present for the debrief
    */
   debriefWitnessed?: boolean;
-  /**
-   * Indicates which form of ID was provided by the candidate
-   */
-  identification?: "Licence" | "Passport";
+  identification?: Identification;
   /**
    * Description of the type of weather encountered during the test
    */

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -377,25 +377,21 @@ export interface Manoeuvres {
     selected?: ManoeuvreIndicator;
     controlFault?: ManoeuvreOutcome;
     observationFault?: ManoeuvreOutcome;
-    [k: string]: any;
   };
   reverseParkRoad?: {
     selected?: ManoeuvreIndicator;
     controlFault?: ManoeuvreOutcome;
     observationFault?: ManoeuvreOutcome;
-    [k: string]: any;
   };
   reverseParkCarpark?: {
     selected?: ManoeuvreIndicator;
     controlFault?: ManoeuvreOutcome;
     observationFault?: ManoeuvreOutcome;
-    [k: string]: any;
   };
   forwardPark?: {
     selected?: ManoeuvreIndicator;
     controlFault?: ManoeuvreOutcome;
     observationFault?: ManoeuvreOutcome;
-    [k: string]: any;
   };
 }
 export interface ControlledStop {

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -329,6 +329,7 @@ export interface TestData {
   vehicleChecks?: VehicleChecks;
   testRequirements?: TestRequirements;
   manoeuvres?: Manoeuvres;
+  controlledStop?: ControlledStop;
   drivingFaults?: DrivingFaults;
   seriousFaults?: SeriousFaults;
   dangerousFaults?: DangerousFaults;
@@ -372,23 +373,34 @@ export interface TestRequirements {
  * The manoeuvres that were carried out during the test and any faults recorded against them
  */
 export interface Manoeuvres {
-  selectedReverseLeft?: ManoeuvreIndicator;
-  outcomeReverseLeftControl?: ManoeuvreOutcome;
-  outcomeReverseLeftObservation?: ManoeuvreOutcome;
-  selectedReverseRight?: ManoeuvreIndicator;
-  outcomeReverseRightControl?: ManoeuvreOutcome;
-  outcomeReverseRightObservation?: ManoeuvreOutcome;
-  selectedReverseParkRoad?: ManoeuvreIndicator;
-  outcomeReverseParkRoadControl?: ManoeuvreOutcome;
-  outcomeReverseParkRoadObservation?: ManoeuvreOutcome;
-  selectedReverseParkCarpark?: ManoeuvreIndicator;
-  outcomeReverseParkCarparkControl?: ManoeuvreOutcome;
-  outcomeReverseParkCarparkObservation?: ManoeuvreOutcome;
-  selectedForwardPark?: ManoeuvreIndicator;
-  outcomeForwardParkControl?: ManoeuvreOutcome;
-  outcomeForwardParkObservation?: ManoeuvreOutcome;
-  selectedControlledStop?: ManoeuvreIndicator;
-  outcomeControlledStop?: ManoeuvreOutcome;
+  reverseRight?: {
+    selected?: ManoeuvreIndicator;
+    controlFault?: ManoeuvreOutcome;
+    observationFault?: ManoeuvreOutcome;
+    [k: string]: any;
+  };
+  reverseParkRoad?: {
+    selected?: ManoeuvreIndicator;
+    controlFault?: ManoeuvreOutcome;
+    observationFault?: ManoeuvreOutcome;
+    [k: string]: any;
+  };
+  reverseParkCarpark?: {
+    selected?: ManoeuvreIndicator;
+    controlFault?: ManoeuvreOutcome;
+    observationFault?: ManoeuvreOutcome;
+    [k: string]: any;
+  };
+  forwardPark?: {
+    selected?: ManoeuvreIndicator;
+    controlFault?: ManoeuvreOutcome;
+    observationFault?: ManoeuvreOutcome;
+    [k: string]: any;
+  };
+}
+export interface ControlledStop {
+  selected?: ManoeuvreIndicator;
+  fault?: ManoeuvreOutcome;
 }
 /**
  * The driving faults accumulated during the test
@@ -685,7 +697,6 @@ export interface FaultSummary {
    * Count of the total number of dangerous faults incurred during the test
    */
   totalDangerousFaults?: number;
-  [k: string]: any;
 }
 /**
  * Finalisation of a successful test outcome

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -423,46 +423,72 @@
       "description": "The manoeuvres that were carried out during the test and any faults recorded against them",
       "type": "object",
       "properties": {
-        "selectedReverseRight": {
+        "reverseRight": {
+          "type": "object",
+          "properties": {
+            "selected": {
+              "$ref": "#/definitions/manoeuvreIndicator"
+            },
+            "controlFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            },
+            "observationFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            }
+          }
+        },
+        "reverseParkRoad": {
+          "type": "object",
+          "properties": {
+            "selected": {
+              "$ref": "#/definitions/manoeuvreIndicator"
+            },
+            "controlFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            },
+            "observationFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            }
+          }
+        },
+        "reverseParkCarpark": {
+          "type": "object",
+          "properties": {
+            "selected": {
+              "$ref": "#/definitions/manoeuvreIndicator"
+            },
+            "controlFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            },
+            "observationFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            }
+          }
+        },
+        "forwardPark": {
+          "type": "object",
+          "properties": {
+            "selected": {
+              "$ref": "#/definitions/manoeuvreIndicator"
+            },
+            "controlFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            },
+            "observationFault": {
+              "$ref": "#/definitions/manoeuvreOutcome"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "controlledStop": {
+      "type": "object",
+      "properties": {
+        "selected": {
           "$ref": "#/definitions/manoeuvreIndicator"
         },
-        "outcomeReverseRightControl": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "outcomeReverseRightObservation": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "selectedReverseParkRoad": {
-          "$ref": "#/definitions/manoeuvreIndicator"
-        },
-        "outcomeReverseParkRoadControl": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "outcomeReverseParkRoadObservation": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "selectedReverseParkCarpark": {
-          "$ref": "#/definitions/manoeuvreIndicator"
-        },
-        "outcomeReverseParkCarparkControl": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "outcomeReverseParkCarparkObservation": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "selectedForwardPark": {
-          "$ref": "#/definitions/manoeuvreIndicator"
-        },
-        "outcomeForwardParkControl": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "outcomeForwardParkObservation": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "selectedControlledStop": {
-          "$ref": "#/definitions/manoeuvreIndicator"
-        },
-        "outcomeControlledStop": {
+        "fault": {
           "$ref": "#/definitions/manoeuvreOutcome"
         }
       },
@@ -1257,7 +1283,8 @@
           "description": "Count of the total number of dangerous faults incurred during the test",
           "type": "integer"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "testData": {
       "description": "Data associated with the test",
@@ -1271,6 +1298,9 @@
         },
         "manoeuvres": {
           "$ref": "#/definitions/manoeuvres"
+        },
+        "controlledStop": {
+          "$ref": "#/definitions/controlledStop"
         },
         "drivingFaults": {
           "$ref": "#/definitions/drivingFaults"

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -423,15 +423,6 @@
       "description": "The manoeuvres that were carried out during the test and any faults recorded against them",
       "type": "object",
       "properties": {
-        "selectedReverseLeft": {
-          "$ref": "#/definitions/manoeuvreIndicator"
-        },
-        "outcomeReverseLeftControl": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
-        "outcomeReverseLeftObservation": {
-          "$ref": "#/definitions/manoeuvreOutcome"
-        },
         "selectedReverseRight": {
           "$ref": "#/definitions/manoeuvreIndicator"
         },

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -1354,6 +1354,22 @@
         "Windy"
       ]
     },
+    "independentDriving": {
+      "description": "Method chosen to conduct the independent driving section of the test",
+      "type": "string",
+      "enum": [
+        "Sat nav",
+        "Traffic signs"
+      ]
+    },
+    "identification": {
+      "description": "Indicates which form of ID was provided by the candidate",
+      "type": "string",
+      "enum": [
+        "Licence",
+        "Passport"
+      ]
+    },
     "testSummary": {
       "description": "Recording of other characteristics of the test",
       "type": "object",
@@ -1363,12 +1379,7 @@
           "type": "integer"
         },
         "independentDriving": {
-          "description": "Method chosen to conduct the independent driving section of the test",
-          "type": "string",
-          "enum": [
-            "Sat nav",
-            "Traffic signs"
-          ]
+          "$ref": "#/definitions/independentDriving"
         },
         "candidateDescription": {
           "description": "Physical description of the candidate",
@@ -1379,12 +1390,7 @@
           "type": "boolean"
         },
         "identification": {
-          "description": "Indicates which form of ID was provided by the candidate",
-          "type": "string",
-          "enum": [
-            "Licence",
-            "Passport"
-          ]
+          "$ref": "#/definitions/identification"
         },
         "weatherConditions": {
           "description": "Description of the type of weather encountered during the test",

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -435,7 +435,8 @@
             "observationFault": {
               "$ref": "#/definitions/manoeuvreOutcome"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "reverseParkRoad": {
           "type": "object",
@@ -449,7 +450,8 @@
             "observationFault": {
               "$ref": "#/definitions/manoeuvreOutcome"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "reverseParkCarpark": {
           "type": "object",
@@ -463,7 +465,8 @@
             "observationFault": {
               "$ref": "#/definitions/manoeuvreOutcome"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "forwardPark": {
           "type": "object",
@@ -477,7 +480,8 @@
             "observationFault": {
               "$ref": "#/definitions/manoeuvreOutcome"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -1344,7 +1348,7 @@
     },
     "postTestDeclarations": {
       "type": "object",
-      "properties": {        
+      "properties": {
         "healthDeclarationAccepted": {
           "description": "Whether or not the candidate has declared that their health status hasn't changed since their last application",
           "type": "boolean"

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
Refactor the Cat B test schema to create objects for each manoeuvre and separate out Controlled Stop.
Generate types for independentDriving and identification.