### PR TITLE
MES-2591/2592: Update test and journal schemas to include fields for RSIS

### DIFF
--- a/mes-journal-schema/Journal.d.ts
+++ b/mes-journal-schema/Journal.d.ts
@@ -107,9 +107,9 @@ export interface TestSlot {
   testCentre?: TestCentre;
   booking?: Booking;
   /**
-   * Whether the test slot is at the examiner's home test centre
+   * Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre
    */
-  isExaminerHomeTestCentre?: boolean;
+  examinerVisiting?: boolean;
 }
 /**
  * Identifier, start time and duration of the slot

--- a/mes-journal-schema/Journal.d.ts
+++ b/mes-journal-schema/Journal.d.ts
@@ -6,6 +6,10 @@
  */
 
 /**
+ * The gender of an individual, limited to 'M' or 'F' as per TARS master data
+ */
+export type Gender = "M" | "F";
+/**
  * The type of special needs test can be YES, NONE or EXTRA
  */
 export type SpecialNeedsCode = "NONE" | "YES" | "EXTRA";
@@ -56,6 +60,10 @@ export interface Examiner {
    * The examiner's DSA staff number
    */
   staffNumber?: string;
+  /**
+   * The individual ID of the examiner
+   */
+  individualId?: number;
   examinerName?: Name;
 }
 /**
@@ -98,6 +106,10 @@ export interface TestSlot {
   vehicleSlotTypeCode?: number;
   testCentre?: TestCentre;
   booking?: Booking;
+  /**
+   * Whether the test slot is at the examiner's home test centre
+   */
+  isExaminerHomeTestCentre?: boolean;
 }
 /**
  * Identifier, start time and duration of the slot
@@ -155,6 +167,11 @@ export interface Candidate {
    * The candidate's driver number if any, typically (though not always) 16 characters if UK, or 8 digits if NI
    */
   driverNumber?: string;
+  /**
+   * The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)
+   */
+  dateOfBirth?: string;
+  gender?: Gender;
   candidateAddress?: Address;
   /**
    * The candidate's primary telephone number, if any (and consent to leave voicemail has been given)
@@ -180,6 +197,10 @@ export interface Candidate {
    * The number of previous test attempts, if an ADI test
    */
   previousADITests?: number;
+  /**
+   * A number defining a candidate's ethnic origin, based on TARS master data
+   */
+  ethnicOriginCode?: number;
 }
 /**
  * Details of the address

--- a/mes-journal-schema/package-lock.json
+++ b/mes-journal-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-journal-schema",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-journal-schema/package.json
+++ b/mes-journal-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-journal-schema",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "JSON Schema of examiner journal data sourced from TARS",
   "types": "Journal.d.ts",
   "scripts": {

--- a/mes-journal-schema/schema-examiner-work-schedule.json
+++ b/mes-journal-schema/schema-examiner-work-schedule.json
@@ -11,6 +11,10 @@
           "type": "string",
           "maxLength": 10
         },
+        "individualId": {
+          "description": "The individual ID of the examiner",
+          "type": "number"
+        },
         "examinerName": {
           "$ref": "#/definitions/name"
         }
@@ -59,6 +63,10 @@
         },
         "booking": {
           "$ref": "#/definitions/booking"
+        },
+        "isExaminerHomeTestCentre": {
+          "description": "Whether the test slot is at the examiner's home test centre",
+          "type": "boolean"
         }
       }
     },
@@ -373,6 +381,15 @@
           "type": "string",
           "maxLength": 24
         },
+        "dateOfBirth": {
+          "description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 10
+        },
+        "gender": {
+          "$ref": "#/definitions/gender"
+        },
         "candidateAddress": {
           "$ref": "#/definitions/address"
         },
@@ -403,6 +420,10 @@
         "previousADITests": {
           "description": "The number of previous test attempts, if an ADI test",
           "type": "integer"
+        },
+        "ethnicOriginCode": {
+          "description": "A number defining a candidate's ethnic origin, based on TARS master data",
+          "type": "number"
         }
       }
     },
@@ -464,6 +485,14 @@
           "maxLength": 20
         }
       }
+    },
+    "gender": {
+      "description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+      "type": "string",
+      "enum": [
+        "M",
+        "F"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/mes-journal-schema/schema-examiner-work-schedule.json
+++ b/mes-journal-schema/schema-examiner-work-schedule.json
@@ -64,8 +64,8 @@
         "booking": {
           "$ref": "#/definitions/booking"
         },
-        "isExaminerHomeTestCentre": {
-          "description": "Whether the test slot is at the examiner's home test centre",
+        "examinerVisiting": {
+          "description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
           "type": "boolean"
         }
       }

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -6,6 +6,10 @@
  */
 
 /**
+ * The gender of an individual, limited to 'M' or 'F' as per TARS master data
+ */
+export type Gender = "M" | "F";
+/**
  * Code representing the result of the test
  */
 export type ActivityCode =
@@ -169,6 +173,10 @@ export interface Examiner {
    * The examiner's DSA staff number
    */
   staffNumber: string;
+  /**
+   * The individual ID of the examiner
+   */
+  individualId?: number;
 }
 /**
  * Details of the test centre
@@ -211,6 +219,10 @@ export interface TestSlotAttributes {
    * Whether this is an extended test
    */
   extendedTest: boolean;
+  /**
+   * Whether the test slot is at the examiner's home test centre
+   */
+  isExaminerHomeTestCentre?: boolean;
 }
 /**
  * Details of the candidate booked into the test slot
@@ -225,6 +237,11 @@ export interface Candidate {
    * The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI
    */
   driverNumber?: string;
+  /**
+   * The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)
+   */
+  dateOfBirth?: string;
+  gender?: Gender;
   candidateAddress?: Address;
   /**
    * The candidate's primary telephone number, if any (and consent to leave voicemail has been given)
@@ -250,6 +267,10 @@ export interface Candidate {
    * The number of previous test attempts, if an ADI test
    */
   previousADITests?: number;
+  /**
+   * A number defining a candidate's ethnic origin, based on TARS master data
+   */
+  ethnicOriginCode?: number;
 }
 /**
  * Details of the individual's name

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -220,9 +220,9 @@ export interface TestSlotAttributes {
    */
   extendedTest: boolean;
   /**
-   * Whether the test slot is at the examiner's home test centre
+   * Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre
    */
-  isExaminerHomeTestCentre?: boolean;
+  examinerVisiting?: boolean;
 }
 /**
  * Details of the candidate booked into the test slot
@@ -374,6 +374,10 @@ export interface Accompaniment {
    * Indicates whether a DVSA supervisor was present during the test
    */
   supervisor?: boolean;
+  /**
+   * Indicates whether an interpreter was present during the test
+   */
+  interpreter?: boolean;
   /**
    * Indicates whether another individual was present during the test
    */

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -10,6 +10,10 @@
           "description": "The examiner's DSA staff number",
           "type": "string",
           "maxLength": 10
+        },
+        "individualId": {
+          "description": "The individual ID of the examiner",
+          "type": "number"
         }
       },
       "additionalProperties": false,
@@ -122,6 +126,15 @@
           "type": "string",
           "maxLength": 24
         },
+        "dateOfBirth": {
+          "description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 10
+        },
+        "gender": {
+          "$ref": "#/definitions/gender"
+        },
         "candidateAddress": {
           "$ref": "#/definitions/address"
         },
@@ -152,6 +165,10 @@
         "previousADITests": {
           "description": "The number of previous test attempts, if an ADI test",
           "type": "integer"
+        },
+        "ethnicOriginCode": {
+          "description": "A number defining a candidate's ethnic origin, based on TARS master data",
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -209,6 +226,10 @@
         },
         "extendedTest": {
           "description": "Whether this is an extended test",
+          "type": "boolean"
+        },
+        "isExaminerHomeTestCentre": {
+          "description": "Whether the test slot is at the examiner's home test centre",
           "type": "boolean"
         }
       },
@@ -1570,6 +1591,14 @@
         "75",
         "82",
         "83"
+      ]
+    },
+    "gender": {
+      "description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+      "type": "string",
+      "enum": [
+        "M",
+        "F"
       ]
     }
   },

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -228,8 +228,8 @@
           "description": "Whether this is an extended test",
           "type": "boolean"
         },
-        "isExaminerHomeTestCentre": {
-          "description": "Whether the test slot is at the examiner's home test centre",
+        "examinerVisiting": {
+          "description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
           "type": "boolean"
         }
       },
@@ -355,6 +355,10 @@
         },
         "supervisor": {
           "description": "Indicates whether a DVSA supervisor was present during the test",
+          "type": "boolean"
+        },
+        "interpreter": {
+          "description": "Indicates whether an interpreter was present during the test",
           "type": "boolean"
         },
         "other": {

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
# Description and relevant Jira numbers
* Include `examinerVisiting`, candidate's `dateOfBirth`, `gender` and `ethnicOriginCode`, examiner's `invididualId` in the journal schema + test schema
* Add a new captured field to test schema, accompaniment by `interpreter`
* Bump to `@dvsa/mes-journal-schema@1.0.7` and `@dvsa/mes-test-schema@1.0.21`

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA