### PR TITLE
MES-2954 - Change application reference from string to number

### DIFF
--- a/mes-search-schema/index.d.ts
+++ b/mes-search-schema/index.d.ts
@@ -15,7 +15,7 @@ export interface SearchResultTestSchema {
   testDate: string;
   driverNumber: string;
   candidateName: Name;
-  applicationReference: string;
+  applicationReference: number;
   category: string;
   activityCode: ActivityCode;
 }

--- a/mes-search-schema/index.json
+++ b/mes-search-schema/index.json
@@ -49,7 +49,7 @@
     },
     "applicationReference": {
       "description": "The application ID",
-      "type": "string"
+      "type": "integer"
     },
     "category": {
       "description": "Category code for the test report",

--- a/mes-search-schema/package.json
+++ b/mes-search-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-search-schema",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Domain model for data returned by the results search API",
   "scripts": {
     "generate-ts-interface": "json2ts -i index.json -o index.d.ts",

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -221,7 +221,7 @@ export interface TestSlotAttributes {
   /**
    * Special needs code
    */
-  specialNeedsCode?: "None" | "Yes" | "Extra";
+  specialNeedsCode?: "NONE" | "YES" | "EXTRA";
   /**
    * Whether the candidate has any special needs that require the D255 form to be completed
    */

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -241,9 +241,9 @@
           "description": "Special needs code",
           "type": "string",
           "enum": [
-            "None",
-            "Yes",
-            "Extra"
+            "NONE",
+            "YES",
+            "EXTRA"
           ]
         },
         "specialNeeds": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
# Description and relevant Jira numbers

- Updated `applicationReference` in searchResult schema to be a number instead of string

- Capitalised all enum values in the `specialNeedsCode` (Szabi requested to combine)

 
## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA