### PR TITLE
MES-3111 - Fix for when terminating test on CCP page and there is no default email, the upload fails validation

### DIFF
--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -65,7 +65,7 @@ export type ActivityCode =
 /**
  * The method of communication by which the candidate agrees to receive their results
  */
-export type CommunicationMethod = "Email" | "Post" | "Support Centre";
+export type CommunicationMethod = "Email" | "Post" | "Support Centre" | "Not provided";
 /**
  * The language in which a candidate agrees to perform a test
  */

--- a/mes-test-schema/categories/B/index.d.ts
+++ b/mes-test-schema/categories/B/index.d.ts
@@ -69,7 +69,7 @@ export type CommunicationMethod = "Email" | "Post" | "Support Centre" | "Not pro
 /**
  * The language in which a candidate agrees to perform a test
  */
-export type ConductedLanguage = "English" | "Cymraeg";
+export type ConductedLanguage = "English" | "Cymraeg" | "Not provided";
 /**
  * Base 64 encoded binary data representing a PNG image of the candidates signature
  */

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -339,7 +339,8 @@
       "type": "string",
       "enum": [
         "English",
-        "Cymraeg"
+        "Cymraeg",
+        "Not provided"
       ]
     },
     "communicationPreferences": {

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -330,7 +330,8 @@
       "enum": [
         "Email",
         "Post",
-        "Support Centre"
+        "Support Centre",
+        "Not provided"
       ]
     },
     "conductedLanguage": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate-cat-b": "json2ts -i categories/B/index.json -o categories/B/index.d.ts",


### PR DESCRIPTION
# Description and relevant Jira numbers
Link to bug - https://jira.dvsacloud.uk/browse/MES-3111

Terminating the test on the CCP where no email is provided and post is not selected - i.e. "By email (new email)" is preselected and no new email is entered. 

Throws the following error

`2019-08-02T13:29:55.897Z 52f1981c-412e-405c-bb13-8fdd8cd013d3 Could not validate the test result body ValidationError: child "communicationPreferences" fails because [child "communicationMethod" fails because ["communicationMethod" is required]]`

Fixed by adding a `Not provided` option to the `communicationMethod` and `conductedLanguage` enums to cover this scenario, at the moment it is defaulted to `null`.

Accompanying mobile app change PR - https://github.com/dvsa/mes-mobile-app/pull/673

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA