### PR TITLE
MES-3926: Creating QuestionResult definition

### DIFF
--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -499,6 +499,7 @@
 			]
 		},
 		"questionResult": {
+			"description": "Result of a vehicle checks question",
 			"additionalProperties": false,
 			"properties": {
 				"code": {

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -498,6 +498,20 @@
 				"D"
 			]
 		},
+		"questionResult": {
+			"additionalProperties": false,
+			"properties": {
+				"code": {
+					"$ref": "#/definitions/questionCode"
+				},
+				"description": {
+					"$ref": "#/definitions/questionDescription"
+				},
+				"outcome": {
+					"$ref": "#/definitions/questionOutcome"
+				}
+			}
+		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"
@@ -1685,37 +1699,13 @@
 			"description": "Details of the Show Me and Tell Me questions asked during the test",
 			"properties": {
 				"showMeQuestion": {
-					"additionalProperties": false,
-					"properties": {
-						"code": {
-							"$ref": "#/definitions/questionCode"
-						},
-						"description": {
-							"$ref": "#/definitions/questionDescription"
-						},
-						"outcome": {
-							"$ref": "#/definitions/questionOutcome"
-						}
-					},
-					"type": "object"
+					"$ref": "#/definitions/questionResult"
 				},
 				"showMeTellMeComments": {
 					"$ref": "#/definitions/faultComments"
 				},
 				"tellMeQuestion": {
-					"additionalProperties": false,
-					"properties": {
-						"code": {
-							"$ref": "#/definitions/questionCode"
-						},
-						"description": {
-							"$ref": "#/definitions/questionDescription"
-						},
-						"outcome": {
-							"$ref": "#/definitions/questionOutcome"
-						}
-					},
-					"type": "object"
+					"$ref": "#/definitions/questionResult"
 				}
 			},
 			"type": "object"

--- a/mes-test-schema/categories/B/partial.d.ts
+++ b/mes-test-schema/categories/B/partial.d.ts
@@ -26,27 +26,6 @@ export type FaultComments = string;
  * via the `definition` "manoeuvreIndicator".
  */
 export type ManoeuvreIndicator = boolean;
-/**
- * Code representing the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBSchema`'s JSON-Schema
- * via the `definition` "questionCode".
- */
-export type QuestionCode = string;
-/**
- * Description of the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBSchema`'s JSON-Schema
- * via the `definition` "questionDescription".
- */
-export type QuestionDescription = string;
-/**
- * Outcome of the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBSchema`'s JSON-Schema
- * via the `definition` "questionOutcome".
- */
-export type QuestionOutcome = "P" | "DF" | "S" | "D";
 
 export interface PartialTestResultCatBSchema {
   instructorDetails?: InstructorDetails;
@@ -140,15 +119,25 @@ export interface Manoeuvres {
  * via the `definition` "vehicleChecks".
  */
 export interface VehicleChecks {
-  showMeQuestion?: {
-    code?: QuestionCode;
-    description?: QuestionDescription;
-    outcome?: QuestionOutcome;
-  };
+  showMeQuestion?: QuestionResult;
   showMeTellMeComments?: FaultComments;
-  tellMeQuestion?: {
-    code?: QuestionCode;
-    description?: QuestionDescription;
-    outcome?: QuestionOutcome;
-  };
+  tellMeQuestion?: QuestionResult;
+}
+/**
+ * This interface was referenced by `PartialTestResultCatBSchema`'s JSON-Schema
+ * via the `definition` "questionResult".
+ */
+export interface QuestionResult {
+  /**
+   * Code representing the question that was asked
+   */
+  code?: string;
+  /**
+   * Description of the question that was asked
+   */
+  description?: string;
+  /**
+   * Outcome of the question that was asked
+   */
+  outcome?: "P" | "DF" | "S" | "D";
 }

--- a/mes-test-schema/categories/B/partial.d.ts
+++ b/mes-test-schema/categories/B/partial.d.ts
@@ -124,6 +124,8 @@ export interface VehicleChecks {
   tellMeQuestion?: QuestionResult;
 }
 /**
+ * Result of a vehicle checks question
+ *
  * This interface was referenced by `PartialTestResultCatBSchema`'s JSON-Schema
  * via the `definition` "questionResult".
  */

--- a/mes-test-schema/categories/B/partial.json
+++ b/mes-test-schema/categories/B/partial.json
@@ -162,51 +162,21 @@
         }
       }
     },
-    "questionCode": {
-      "$ref": "../common/index.json#/definitions/questionCode"
-    },
-    "questionDescription": {
-      "$ref": "../common/index.json#/definitions/questionDescription"
-    },
-    "questionOutcome": {
-      "$ref": "../common/index.json#/definitions/questionOutcome"
+    "questionResult": {
+      "$ref": "../common/index.json#/definitions/questionResult"
     },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",
       "properties": {
         "showMeQuestion": {
-          "additionalProperties": false,
-          "properties": {
-            "code": {
-              "$ref": "#/definitions/questionCode"
-            },
-            "description": {
-              "$ref": "#/definitions/questionDescription"
-            },
-            "outcome": {
-              "$ref": "#/definitions/questionOutcome"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/questionResult"
         },
         "showMeTellMeComments": {
           "$ref": "#/definitions/faultComments"
         },
         "tellMeQuestion": {
-          "additionalProperties": false,
-          "properties": {
-            "code": {
-              "$ref": "#/definitions/questionCode"
-            },
-            "description": {
-              "$ref": "#/definitions/questionDescription"
-            },
-            "outcome": {
-              "$ref": "#/definitions/questionOutcome"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/questionResult"
         }
       },
       "type": "object"

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -507,6 +507,20 @@
 				"D"
 			]
 		},
+		"questionResult": {
+			"additionalProperties": false,
+			"properties": {
+				"code": {
+					"$ref": "#/definitions/questionCode"
+				},
+				"description": {
+					"$ref": "#/definitions/questionDescription"
+				},
+				"outcome": {
+					"$ref": "#/definitions/questionOutcome"
+				}
+			}
+		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"
@@ -1619,21 +1633,9 @@
 			"additionalProperties": false,
 			"description": "Details of the Show Me and Tell Me questions asked during the test",
 			"properties": {
-				"showMeQuestion": {
+				"showMeQuestions": {
 					"items": {
-						"additionalProperties": false,
-						"properties": {
-							"code": {
-								"$ref": "#/definitions/questionCode"
-							},
-							"description": {
-								"$ref": "#/definitions/questionDescription"
-							},
-							"outcome": {
-								"$ref": "#/definitions/questionOutcome"
-							}
-						},
-						"type": "object"
+						"$ref": "#/definitions/questionResult"
 					},
 					"type": "array"
 				},
@@ -1642,19 +1644,7 @@
 				},
 				"tellMeQuestions": {
 					"items": {
-						"additionalProperties": false,
-						"properties": {
-							"code": {
-								"$ref": "#/definitions/questionCode"
-							},
-							"description": {
-								"$ref": "#/definitions/questionDescription"
-							},
-							"outcome": {
-								"$ref": "#/definitions/questionOutcome"
-							}
-						},
-						"type": "object"
+						"$ref": "#/definitions/questionResult"
 					},
 					"type": "array"
 				}

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -508,6 +508,7 @@
 			]
 		},
 		"questionResult": {
+			"description": "Result of a vehicle checks question",
 			"additionalProperties": false,
 			"properties": {
 				"code": {

--- a/mes-test-schema/categories/BE/partial.d.ts
+++ b/mes-test-schema/categories/BE/partial.d.ts
@@ -126,6 +126,8 @@ export interface VehicleChecks {
   tellMeQuestions?: QuestionResult[];
 }
 /**
+ * Result of a vehicle checks question
+ *
  * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
  * via the `definition` "questionResult".
  */

--- a/mes-test-schema/categories/BE/partial.d.ts
+++ b/mes-test-schema/categories/BE/partial.d.ts
@@ -27,27 +27,6 @@ export type FaultComments = string;
  */
 export type ManoeuvreIndicator = boolean;
 /**
- * Code representing the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
- * via the `definition` "questionCode".
- */
-export type QuestionCode = string;
-/**
- * Description of the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
- * via the `definition` "questionDescription".
- */
-export type QuestionDescription = string;
-/**
- * Outcome of the question that was asked
- *
- * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
- * via the `definition` "questionOutcome".
- */
-export type QuestionOutcome = "P" | "DF" | "S" | "D";
-/**
  * Name of the business the candidate relates to
  *
  * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
@@ -142,17 +121,27 @@ export interface Manoeuvres {
  * via the `definition` "vehicleChecks".
  */
 export interface VehicleChecks {
-  showMeQuestion?: {
-    code?: QuestionCode;
-    description?: QuestionDescription;
-    outcome?: QuestionOutcome;
-  }[];
+  showMeQuestions?: QuestionResult[];
   showMeTellMeComments?: FaultComments;
-  tellMeQuestions?: {
-    code?: QuestionCode;
-    description?: QuestionDescription;
-    outcome?: QuestionOutcome;
-  }[];
+  tellMeQuestions?: QuestionResult[];
+}
+/**
+ * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
+ * via the `definition` "questionResult".
+ */
+export interface QuestionResult {
+  /**
+   * Code representing the question that was asked
+   */
+  code?: string;
+  /**
+   * Description of the question that was asked
+   */
+  description?: string;
+  /**
+   * Outcome of the question that was asked
+   */
+  outcome?: "P" | "DF" | "S" | "D";
 }
 /**
  * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema

--- a/mes-test-schema/categories/BE/partial.json
+++ b/mes-test-schema/categories/BE/partial.json
@@ -39,34 +39,16 @@
         }
       }
     },
-    "questionCode": {
-      "$ref": "../common/index.json#/definitions/questionCode"
-    },
-    "questionDescription": {
-      "$ref": "../common/index.json#/definitions/questionDescription"
-    },
-    "questionOutcome": {
-      "$ref": "../common/index.json#/definitions/questionOutcome"
+    "questionResult": {
+      "$ref": "../common/index.json#/definitions/questionResult"
     },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",
       "properties": {
-        "showMeQuestion": {
+        "showMeQuestions": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "code": {
-                "$ref": "#/definitions/questionCode"
-              },
-              "description": {
-                "$ref": "#/definitions/questionDescription"
-              },
-              "outcome": {
-                "$ref": "#/definitions/questionOutcome"
-              }
-            },
-            "type": "object"
+            "$ref": "#/definitions/questionResult"
           },
           "type": "array"
         },
@@ -75,19 +57,7 @@
         },
         "tellMeQuestions": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "code": {
-                "$ref": "#/definitions/questionCode"
-              },
-              "description": {
-                "$ref": "#/definitions/questionDescription"
-              },
-              "outcome": {
-                "$ref": "#/definitions/questionOutcome"
-              }
-            },
-            "type": "object"
+            "$ref": "#/definitions/questionResult"
           },
           "type": "array"
         }

--- a/mes-test-schema/categories/Common/index.d.ts
+++ b/mes-test-schema/categories/Common/index.d.ts
@@ -1017,3 +1017,12 @@ export interface TestRequirements {
    */
   normalStart2?: boolean;
 }
+/**
+ * This interface was referenced by `TestResultCommonSchema`'s JSON-Schema
+ * via the `definition` "questionResult".
+ */
+export interface QuestionResult {
+  code?: QuestionCode;
+  description?: QuestionDescription;
+  outcome?: QuestionOutcome;
+}

--- a/mes-test-schema/categories/Common/index.d.ts
+++ b/mes-test-schema/categories/Common/index.d.ts
@@ -1018,6 +1018,8 @@ export interface TestRequirements {
   normalStart2?: boolean;
 }
 /**
+ * Result of a vehicle checks question
+ *
  * This interface was referenced by `TestResultCommonSchema`'s JSON-Schema
  * via the `definition` "questionResult".
  */

--- a/mes-test-schema/categories/Common/index.json
+++ b/mes-test-schema/categories/Common/index.json
@@ -490,6 +490,7 @@
       ]
     },
     "questionResult": {
+      "description": "Result of a vehicle checks question",
       "additionalProperties": false,
       "properties": {
         "code": {

--- a/mes-test-schema/categories/Common/index.json
+++ b/mes-test-schema/categories/Common/index.json
@@ -489,6 +489,20 @@
         "D"
       ]
     },
+    "questionResult": {
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/questionCode"
+        },
+        "description": {
+          "$ref": "#/definitions/questionDescription"
+        },
+        "outcome": {
+          "$ref": "#/definitions/questionOutcome"
+        }
+      }
+    },
     "manoeuvreIndicator": {
       "description": "Indicator for a manoeuvre being performed during the test",
       "type": "boolean"

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
Creating a common definition for QuestionResult and referencing that for ShowMe/TellMe Questions in vehicle checks.