### PR TITLE
MES-4239: Removing code 78 for Category B+E

### DIFF
--- a/mes-test-schema/categories/BE/index.d.ts
+++ b/mes-test-schema/categories/BE/index.d.ts
@@ -5,10 +5,9 @@
  */
 
 // Always follow the order of the properties that are in partial.d.ts
-import { PartialTestResultCatBESchema, PassCompletion } from './partial';
+import { PartialTestResultCatBESchema } from './partial';
 import { TestResultCommonSchema } from '../common/index';
 import { PassCompletion as CommonPassCompletion } from '../common/index';
-import { PassCompletion as PartialCatBePassCompletion } from './partial';
 import { TestData as PartialCatBETestData } from './partial';
 import { TestData as CommonTestData } from '../common';
 import { UncoupleRecouple as PartialCatBEUncoupleRecouple } from './partial';
@@ -25,8 +24,6 @@ import { VehicleDetails as CommonVehicleDetails } from '../common/index';
 
 export declare namespace CatBEUniqueTypes {
   type TestResult = PartialTestResultCatBESchema & TestResultCommonSchema;
-
-  type PassCompletion = PartialCatBePassCompletion & CommonPassCompletion;
 
   type TestData = PartialCatBETestData & CommonTestData;
  

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -1650,17 +1650,12 @@
 					"type": "string",
 					"maxLength": 8,
 					"minLength": 8
-				},
-				"code78Present": {
-					"description": "Indicate presence of code 78 (automatic) on candidates license",
-					"type": "boolean"
 				}
 			},
 			"additionalProperties": false,
 			"required": [
 				"provisionalLicenceProvided",
-				"passCertificateNumber",
-				"code78Present"
+				"passCertificateNumber"
 			]
 		},
 		"manoeuvres": {

--- a/mes-test-schema/categories/BE/partial.d.ts
+++ b/mes-test-schema/categories/BE/partial.d.ts
@@ -42,21 +42,8 @@ export type BusinessName = string;
 export type BusinessTelephone = string;
 
 export interface PartialTestResultCatBESchema {
-  passCompletion?: PassCompletion;
   testData?: TestData;
   journalData: JournalData;
-}
-/**
- * Finalisation of a successful test outcome
- *
- * This interface was referenced by `PartialTestResultCatBESchema`'s JSON-Schema
- * via the `definition` "passCompletion".
- */
-export interface PassCompletion {
-  /**
-   * Indicate presence of code 78 (automatic) on candidates license
-   */
-  code78Present: boolean;
 }
 /**
  * Data associated with the test

--- a/mes-test-schema/categories/BE/partial.json
+++ b/mes-test-schema/categories/BE/partial.json
@@ -102,20 +102,6 @@
       "type": "object",
       "additionalProperties": false
     },
-    "passCompletion": {
-      "description": "Finalisation of a successful test outcome",
-      "type": "object",
-      "properties": {
-        "code78Present": {
-          "description": "Indicate presence of code 78 (automatic) on candidates license",
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "code78Present"
-      ]
-    },
     "uncoupleRecouple": {
       "additionalProperties": false,
       "properties": {
@@ -171,9 +157,6 @@
     }
   },
   "properties": {
-    "passCompletion": {
-      "$ref": "#/definitions/passCompletion"
-    },
     "testData": {
       "$ref": "#/definitions/testData"
     },

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
- Removing `code78Present` for Category B+E
- Removing `PassCompletion` from `index.d.ts`
## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA