### PR TITLE
prevent additional anonymous properties

### DIFF
--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -1401,7 +1401,8 @@
 					"description": "Any comments that the DE wants to record about the test",
 					"type": "string"
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"categoryCode": {
 			"description": "Category code for the test report",

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -1411,7 +1411,8 @@
 					"description": "Any comments that the DE wants to record about the test",
 					"type": "string"
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"categoryCode": {
 			"description": "Category code for the test report",

--- a/mes-test-schema/categories/common/index.d.ts
+++ b/mes-test-schema/categories/common/index.d.ts
@@ -610,7 +610,6 @@ export interface TestSummary {
    * Any comments that the DE wants to record about the test
    */
   additionalInformation?: string;
-  [k: string]: any;
 }
 /**
  * Recording of the rekey reason

--- a/mes-test-schema/categories/common/index.json
+++ b/mes-test-schema/categories/common/index.json
@@ -1392,7 +1392,8 @@
           "description": "Any comments that the DE wants to record about the test",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "categoryCode": {
       "description": "Category code for the test report",

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
- Adds the `"additionalProperties": false` key to the `TestSummary` interface in order to prevent anonymous properties being added into the test result.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA