### PR TITLE
Fix vehicle checks for enjoi

### DIFF
--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -522,6 +522,7 @@
 		},
 		"questionResult": {
 			"description": "Result of a vehicle checks question",
+			"type": "object",
 			"additionalProperties": false,
 			"properties": {
 				"code": {

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -532,6 +532,7 @@
 		},
 		"questionResult": {
 			"description": "Result of a vehicle checks question",
+			"type": "object",
 			"additionalProperties": false,
 			"properties": {
 				"code": {

--- a/mes-test-schema/categories/common/index.json
+++ b/mes-test-schema/categories/common/index.json
@@ -513,6 +513,7 @@
     },
     "questionResult": {
       "description": "Result of a vehicle checks question",
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "code": {

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
- Adds the `type` key to the `questionResult` definition in the common json schema.
- Generates the new category specific json schemas.

Addresses the following error seen in dev which was causing vehicle checks validation to be bypassed -
```
2019-12-09T10:36:15.806Z    1e3ba2cf-50e7-4248-86bd-5adcd37595e2    WARN    WARNING: schema missing a 'type' or '$ref' or 'enum': 
{
    "description": "Result of a vehicle checks question",
    "additionalProperties": false,
    "properties": {
        "code": {
            "$ref": "#/definitions/questionCode"
        },
        "description": {
            "$ref": "#/definitions/questionDescription"
        },
        "outcome": {
            "$ref": "#/definitions/questionOutcome"
        }
    }
}
```

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA