### PR TITLE
MES-4633: Adding AM1 and AM2 TestResults to the Union

### DIFF
--- a/mes-test-schema/categories/index.d.ts
+++ b/mes-test-schema/categories/index.d.ts
@@ -5,6 +5,8 @@ import { CatCUniqueTypes } from './C';
 import { CatCEUniqueTypes } from './CE';
 import { CatC1UniqueTypes } from './C1';
 import { CatC1EUniqueTypes } from './C1E';
+import { TestResultCatAM1Schema } from './AM1';
+import { TestResultCatAM2Schema } from './AM2';
 
 export type TestResultSchemasUnion =
   | CatBUniqueTypes.TestResult
@@ -12,4 +14,6 @@ export type TestResultSchemasUnion =
   | CatCUniqueTypes.TestResult
   | CatCEUniqueTypes.TestResult
   | CatC1UniqueTypes.TestResult
-  | CatC1EUniqueTypes.TestResult;
+  | CatC1EUniqueTypes.TestResult
+  | TestResultCatAM1Schema
+  | TestResultCatAM2Schema;


### PR DESCRIPTION
# Description and relevant Jira numbers

Extending the `TestResultSchemasUnion` with `TestResultCatAM1Schema` & `TestResultCatAM2Schema`