### PR TITLE
Fixes to Mod2 Schema missing eyesight and CBT cert

### DIFF
--- a/mes-test-schema/categories/AM2/index.d.ts
+++ b/mes-test-schema/categories/AM2/index.d.ts
@@ -104,12 +104,12 @@ export type ActivityCode =
  */
 export type Signature = string;
 /**
- * The number of the Mod 1 certificate presented by the candidate
+ * The number of the DL196 CBT certificate presented by the candidate
  *
  * This interface was referenced by `TestResultCatAM2Schema`'s JSON-Schema
- * via the `definition` "mod1CertificateNumber".
+ * via the `definition` "DL196CBTCertNumber".
  */
-export type Mod1CertificateNumber = string;
+export type DL196CBTCertNumber = string;
 /**
  * Method chosen to conduct the independent driving section of the test
  *
@@ -476,7 +476,7 @@ export interface PreTestDeclarations {
    */
   residencyDeclarationAccepted: boolean;
   preTestSignature: Signature;
-  mod1CertificateNumber: Mod1CertificateNumber;
+  DL196CBTCertNumber?: DL196CBTCertNumber;
 }
 /**
  * Indicators for anybody else overseeing the test
@@ -648,6 +648,7 @@ export interface TestData {
   dangerousFaults?: DangerousFaults;
   safetyAndBalanceQuestions?: SafetyAndBalanceQuestions;
   eco?: Eco;
+  eyesightTest?: EyesightTest;
 }
 /**
  * Indicates whether the examiner had to take verbal action during the test

--- a/mes-test-schema/categories/AM2/index.json
+++ b/mes-test-schema/categories/AM2/index.json
@@ -28,12 +28,6 @@
     "signature": {
       "$ref": "../common/index.json#/definitions/signature"
     },
-    "mod1CertificateNumber": {
-      "description": "The number of the Mod 1 certificate presented by the candidate",
-      "type": "string",
-      "maxLength": 8,
-      "minLength": 8
-    },
     "journalData": {
       "$ref": "../common/index.json#/definitions/journalData"
     },
@@ -58,8 +52,8 @@
         "preTestSignature": {
           "$ref": "#/definitions/signature"
         },
-        "mod1CertificateNumber": {
-          "$ref": "#/definitions/mod1CertificateNumber"
+        "DL196CBTCertNumber": {
+          "$ref": "#/definitions/DL196CBTCertNumber"
         }
       },
       "required": [
@@ -950,9 +944,16 @@
         },
         "eco": {
           "$ref": "#/definitions/eco"
+        },
+        "eyesightTest": {
+          "$ref": "#/definitions/eyesightTest"
         }
       },
       "additionalProperties": false
+    },
+    "DL196CBTCertNumber": {
+      "description": "The number of the DL196 CBT certificate presented by the candidate",
+      "type": "string"
     }
   },
   "properties": {

--- a/mes-test-schema/category-definitions/AM2/index.json
+++ b/mes-test-schema/category-definitions/AM2/index.json
@@ -28,12 +28,6 @@
     "signature": {
       "$ref": "../common/index.json#/definitions/signature"
     },
-    "mod1CertificateNumber": {
-      "description": "The number of the Mod 1 certificate presented by the candidate",
-      "type": "string",
-      "maxLength": 8,
-      "minLength": 8
-    },
     "journalData": {
       "$ref": "../common/index.json#/definitions/journalData"
     },
@@ -58,8 +52,8 @@
         "preTestSignature": {
           "$ref": "#/definitions/signature"
         },
-        "mod1CertificateNumber": {
-          "$ref": "#/definitions/mod1CertificateNumber"
+        "DL196CBTCertNumber": {
+          "$ref": "#/definitions/DL196CBTCertNumber"
         }
       },
       "required": [
@@ -950,9 +944,16 @@
         },
         "eco": {
           "$ref": "#/definitions/eco"
+        },
+        "eyesightTest": {
+          "$ref": "#/definitions/eyesightTest"
         }
       },
       "additionalProperties": false
+    },
+    "DL196CBTCertNumber": {
+      "description": "The number of the DL196 CBT certificate presented by the candidate",
+      "type": "string"
     }
   },
   "properties": {

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
Bug of MES-4402
Included EyeSight Check into the TestData type
Removed Mod1 certificate number from Mod2; replaced with DL196CBTCertNumber

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name complies with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA