### PR TITLE
MES-4803 de-reference Mod1 and Mod2 schemas.

### DIFF
--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -1,478 +1,2543 @@
 {
-  "title": "Test Result Cat AM1 Schema",
-  "type": "object",
-  "definitions": {
-    "circuit": {
-      "description": "Circuit completed (left or right)",
-      "type": "string",
-      "enum": [
-        "Left",
-        "Right"
-      ]
-    },
-    "testData": {
-      "additionalProperties": false,
-      "description": "Data associated with the test",
-      "properties": {
-        "useOfStand": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "manualHandling": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "slalom": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "slowControl": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "uTurn": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "controlledStop": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "emergencyStop": {
-          "$ref": "#/definitions/emergencyStop"
-        },
-        "avoidance": {
-          "$ref": "#/definitions/avoidance"
-        },
-        "drivingFaults": {
-          "$ref": "#/definitions/drivingFaults"
-        },
-        "seriousFaults": {
-          "$ref": "#/definitions/seriousFaults"
-        },
-        "dangerousFaults": {
-          "$ref": "#/definitions/dangerousFaults"
-        },
-        "ETA": {
-          "$ref": "#/definitions/ETA"
-        }
-      },
-      "type": "object"
-    },
-    "singleFaultCompetencyOutcome": {
-      "description": "The possible outcomes of any single fault competency",
-      "enum": [
-        "DF",
-        "S",
-        "D"
-      ],
-      "type": "string"
-    },
-    "examiner": {
-      "$ref": "../common/index.json#/definitions/examiner"
-    },
-    "testCentre": {
-      "$ref": "../common/index.json#/definitions/testCentre"
-    },
-    "name": {
-      "$ref": "../common/index.json#/definitions/name"
-    },
-    "address": {
-      "$ref": "../common/index.json#/definitions/address"
-    },
-    "candidate": {
-      "$ref": "../common/index.json#/definitions/candidate"
-    },
-    "applicationReference": {
-      "$ref": "../common/index.json#/definitions/applicationReference"
-    },
-    "initiator": {
-      "$ref": "../common/index.json#/definitions/initiator"
-    },
-    "testSlotAttributes": {
-      "$ref": "../common/index.json#/definitions/testSlotAttributes"
-    },
-    "journalData": {
-      "$ref": "../common/index.json#/definitions/journalData"
-    },
-    "signature": {
-      "$ref": "../common/index.json#/definitions/signature"
-    },
-    "communicationMethod": {
-      "$ref": "../common/index.json#/definitions/communicationMethod"
-    },
-    "conductedLanguage": {
-      "$ref": "../common/index.json#/definitions/conductedLanguage"
-    },
-    "communicationPreferences": {
-      "$ref": "../common/index.json#/definitions/communicationPreferences"
-    },
-    "preTestDeclarations": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "insuranceDeclarationAccepted": {
-          "description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
-          "type": "boolean"
-        },
-        "residencyDeclarationAccepted": {
-          "description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
-          "type": "boolean"
-        },
-        "preTestSignature": {
-          "$ref": "#/definitions/signature"
-        },
-        "DL196CBTCertNumber": {
-          "$ref": "#/definitions/DL196CBTCertNumber"
-        }
-      },
-      "required": [
-        "insuranceDeclarationAccepted",
-        "residencyDeclarationAccepted",
-        "preTestSignature"
-      ]
-    },
-    "accompaniment": {
-      "$ref": "../common/index.json#/definitions/accompaniment"
-    },
-    "gearboxCategory": {
-      "$ref": "../common/index.json#/definitions/gearboxCategory"
-    },
-    "drivingFaultCount": {
-      "$ref": "../common/index.json#/definitions/drivingFaultCount"
-    },
-    "faultComments": {
-      "$ref": "../common/index.json#/definitions/faultComments"
-    },
-    "drivingFaults": {
-      "description": "The driving faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "precautions": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "precautionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "seriousFaultIndicator": {
-      "$ref": "../common/index.json#/definitions/seriousFaultIndicator"
-    },
-    "seriousFaults": {
-      "description": "The serious faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "precautions": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "precautionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "dangerousFaultIndicator": {
-      "$ref": "../common/index.json#/definitions/dangerousFaultIndicator"
-    },
-    "dangerousFaults": {
-      "description": "The dangerous faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "precautions": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "precautionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "postTestDeclarations": {
-      "$ref": "../common/index.json#/definitions/postTestDeclarations"
-    },
-    "weatherConditions": {
-      "$ref": "../common/index.json#/definitions/weatherConditions"
-    },
-    "identification": {
-      "$ref": "../common/index.json#/definitions/identification"
-    },
-    "testSummary": {
-      "description": "Recording of other characteristics of the test",
-      "type": "object",
-      "properties": {
-        "routeNumber": {
-          "description": "Number of the route that was taken during the test",
-          "type": "integer",
-          "const": 88
-        },
-        "candidateDescription": {
-          "description": "Physical description of the candidate",
-          "type": "string",
-          "maxLength": 1000
-        },
-        "debriefWitnessed": {
-          "description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
-          "type": "boolean"
-        },
-        "identification": {
-          "$ref": "#/definitions/identification"
-        },
-        "weatherConditions": {
-          "description": "Description of the type of weather encountered during the test",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/weatherConditions"
-          }
-        },
-        "D255": {
-          "description": "Indicates whether a D255 form needs to be completed",
-          "type": "boolean"
-        },
-        "additionalInformation": {
-          "description": "Any comments that the DE wants to record about the test",
-          "type": "string"
-        },
-        "circuit": {
-          "$ref": "#/definitions/circuit"
-        }
-      },
-      "additionalProperties": false
-    },
-    "categoryCode": {
-      "$ref": "../common/index.json#/definitions/categoryCode"
-    },
-    "activityCode": {
-      "$ref": "../common/index.json#/definitions/activityCode"
-    },
-    "gender": {
-      "$ref": "../common/index.json#/definitions/gender"
-    },
-    "rekeyReason": {
-      "$ref": "../common/index.json#/definitions/rekeyReason"
-    },
-    "transfer": {
-      "$ref": "../common/index.json#/definitions/transfer"
-    },
-    "ipadIssue": {
-      "$ref": "../common/index.json#/definitions/ipadIssue"
-    },
-    "other": {
-      "$ref": "../common/index.json#/definitions/other"
-    },
-    "vehicleDetails": {
-      "description": "Details about the vehicle to be used for the test",
-      "type": "object",
-      "properties": {
-        "registrationNumber": {
-          "description": "The vehicle registration number",
-          "type": "string",
-          "maxLength": 7
-        },
-        "gearboxCategory": {
-          "$ref": "#/definitions/gearboxCategory"
-        },
-        "schoolBike": {
-          "$ref": "#/definitions/schoolBike"
-        }
-      },
-      "additionalProperties": false
-    },
-    "passCompletion": {
-      "description": "Finalisation of a successful test outcome",
-      "type": "object",
-      "properties": {
-        "provisionalLicenceProvided": {
-          "description": "Indicates whether the candidate submitted their provisional driving licence",
-          "type": "boolean"
-        },
-        "passCertificateNumber": {
-          "description": "The PCN issued to the candidate",
-          "type": "string",
-          "maxLength": 8,
-          "minLength": 8
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "provisionalLicenceProvided",
-        "passCertificateNumber"
-      ]
-    },
-    "DL196CBTCertNumber": {
-      "description": "The number of the DL196 CBT certificate presented by the candidate",
-      "type": "string"
-    },
-    "avoidance": {
-      "description": "The outcome of avoidance tests",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "firstAttempt": {
-          "description": "The speed of the first attempt",
-          "type": "integer"
-        },
-        "secondAttempt": {
-          "description": "The speed of the second attempt",
-          "type": "integer"
-        },
-        "speedNotMetSeriousFault": {
-          "description": "Whether the required speed was not met",
-          "type": "boolean"
-        },
-        "outcome": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        }
-      }
-    },
-    "emergencyStop": {
-      "description": "The outcome of emergency stop tests",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "firstAttempt": {
-          "description": "The speed of the first attempt",
-          "type": "integer"
-        },
-        "secondAttempt": {
-          "description": "The speed of the second attempt",
-          "type": "integer"
-        },
-        "speedNotMetSeriousFault": {
-          "description": "Whether the required speed was not met",
-          "type": "boolean"
-        },
-        "outcome": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        }
-      }
-    },
-    "ETA": {
-      "$ref": "../common/index.json#/definitions/ETA"
-    },
-    "schoolBike": {
-      "description": "Indicates whether the bike belongs to a driving school",
-      "type": "boolean"
-    },
-    "businessName": {
-      "description": "Name of the business the candidate relates to",
-      "type": "string",
-      "maxLength": 100
-    },
-    "businessTelephone": {
-      "description": "Telephone number of the business the candidate relates to",
-      "type": "string",
-      "maxLength": 20
-    }
-  },
-  "properties": {
-    "version": {
-      "description": "Version number",
-      "type": "string"
-    },
-    "category": {
-      "$ref": "#/definitions/categoryCode"
-    },
-    "journalData": {
-      "$ref": "#/definitions/journalData"
-    },
-    "activityCode": {
-      "$ref": "#/definitions/activityCode"
-    },
-    "communicationPreferences": {
-      "$ref": "#/definitions/communicationPreferences"
-    },
-    "preTestDeclarations": {
-      "$ref": "#/definitions/preTestDeclarations"
-    },
-    "accompaniment": {
-      "$ref": "#/definitions/accompaniment"
-    },
-    "postTestDeclarations": {
-      "$ref": "#/definitions/postTestDeclarations"
-    },
-    "testSummary": {
-      "$ref": "#/definitions/testSummary"
-    },
-    "rekeyReason": {
-      "$ref": "#/definitions/rekeyReason"
-    },
-    "rekey": {
-      "description": "Whether the test was rekeyed or not",
-      "type": "boolean"
-    },
-    "rekeyDate": {
-      "description": "Date the test was rekeyed",
-      "type": "string"
-    },
-    "changeMarker": {
-      "description": "Whether the test was conducted by another examiner",
-      "type": "boolean"
-    },
-    "examinerBooked": {
-      "description": "The examiner who the test was booked to",
-      "type": "number"
-    },
-    "examinerConducted": {
-      "description": "The examiner who conducted the test",
-      "type": "number"
-    },
-    "examinerKeyed": {
-      "description": "The examiner who keyed the test into the iPad",
-      "type": "number"
-    },
-    "passCompletion": {
-      "$ref": "#/definitions/passCompletion"
-    },
-    "vehicleDetails": {
-      "$ref": "#/definitions/vehicleDetails"
-    },
-    "testData": {
-      "$ref": "#/definitions/testData"
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "version",
-    "category",
-    "journalData",
-    "activityCode",
-    "rekey",
-    "changeMarker",
-    "examinerBooked",
-    "examinerConducted",
-    "examinerKeyed",
-    "journalData"
-  ]
+	"title": "Test Result Cat AM1 Schema",
+	"type": "object",
+	"definitions": {
+		"circuit": {
+			"description": "Circuit completed (left or right)",
+			"type": "string",
+			"enum": [
+				"Left",
+				"Right"
+			]
+		},
+		"testData": {
+			"additionalProperties": false,
+			"description": "Data associated with the test",
+			"properties": {
+				"useOfStand": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"manualHandling": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slalom": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slowControl": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"uTurn": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"controlledStop": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"emergencyStop": {
+					"description": "The outcome of emergency stop tests",
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"firstAttempt": {
+							"description": "The speed of the first attempt",
+							"type": "integer"
+						},
+						"secondAttempt": {
+							"description": "The speed of the second attempt",
+							"type": "integer"
+						},
+						"speedNotMetSeriousFault": {
+							"description": "Whether the required speed was not met",
+							"type": "boolean"
+						},
+						"outcome": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						}
+					}
+				},
+				"avoidance": {
+					"description": "The outcome of avoidance tests",
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"firstAttempt": {
+							"description": "The speed of the first attempt",
+							"type": "integer"
+						},
+						"secondAttempt": {
+							"description": "The speed of the second attempt",
+							"type": "integer"
+						},
+						"speedNotMetSeriousFault": {
+							"description": "Whether the required speed was not met",
+							"type": "boolean"
+						},
+						"outcome": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						}
+					}
+				},
+				"drivingFaults": {
+					"description": "The driving faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"seriousFaults": {
+					"description": "The serious faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"dangerousFaults": {
+					"description": "The dangerous faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"ETA": {
+					"description": "Indicates whether the examiner had to take physical or verbal action during the test",
+					"type": "object",
+					"properties": {
+						"physical": {
+							"description": "Indicates that the examiner had to take physical action",
+							"type": "boolean"
+						},
+						"verbal": {
+							"description": "Indicates that the examiner had to take verbal action",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"type": "object"
+		},
+		"singleFaultCompetencyOutcome": {
+			"description": "The possible outcomes of any single fault competency",
+			"enum": [
+				"DF",
+				"S",
+				"D"
+			],
+			"type": "string"
+		},
+		"examiner": {
+			"description": "The examiner details",
+			"type": "object",
+			"properties": {
+				"staffNumber": {
+					"description": "The examiner's DSA staff number",
+					"type": "string",
+					"maxLength": 10
+				},
+				"individualId": {
+					"description": "The individual ID of the examiner",
+					"type": "number"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"staffNumber"
+			]
+		},
+		"testCentre": {
+			"description": "Details of the test centre",
+			"type": "object",
+			"properties": {
+				"centreId": {
+					"description": "Identifer for the test centre",
+					"type": "integer"
+				},
+				"costCode": {
+					"description": "Cost centre code for the test centre",
+					"type": "string",
+					"maxLength": 6
+				},
+				"centreName": {
+					"description": "Name of the test centre",
+					"type": "string",
+					"maxLength": 50
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"centreId",
+				"costCode"
+			]
+		},
+		"name": {
+			"description": "Details of the individual's name",
+			"type": "object",
+			"properties": {
+				"title": {
+					"description": "The individual's title",
+					"type": "string",
+					"maxLength": 7
+				},
+				"firstName": {
+					"description": "The individual's forename",
+					"type": "string",
+					"maxLength": 50
+				},
+				"secondName": {
+					"description": "The individual's second name",
+					"type": "string",
+					"maxLength": 50
+				},
+				"thirdName": {
+					"description": "The individual's third name",
+					"type": "string",
+					"maxLength": 50
+				},
+				"lastName": {
+					"description": "The individual's surname",
+					"type": "string",
+					"maxLength": 50
+				}
+			},
+			"additionalProperties": false
+		},
+		"address": {
+			"description": "Details of the address",
+			"type": "object",
+			"properties": {
+				"addressLine1": {
+					"description": "First line of address",
+					"type": "string",
+					"maxLength": 255
+				},
+				"addressLine2": {
+					"description": "Second line of address",
+					"type": "string",
+					"maxLength": 100
+				},
+				"addressLine3": {
+					"description": "Third line of address",
+					"type": "string",
+					"maxLength": 100
+				},
+				"addressLine4": {
+					"description": "Fourth line of address",
+					"type": "string",
+					"maxLength": 100
+				},
+				"addressLine5": {
+					"description": "Fifth line of address",
+					"type": "string",
+					"maxLength": 255
+				},
+				"postcode": {
+					"description": "The address postcode",
+					"type": "string",
+					"maxLength": 255
+				}
+			},
+			"additionalProperties": false
+		},
+		"candidate": {
+			"description": "Details of the candidate booked into the test slot",
+			"type": "object",
+			"properties": {
+				"candidateId": {
+					"description": "The id of the test candidate",
+					"type": "integer"
+				},
+				"candidateName": {
+					"description": "Details of the individual's name",
+					"type": "object",
+					"properties": {
+						"title": {
+							"description": "The individual's title",
+							"type": "string",
+							"maxLength": 7
+						},
+						"firstName": {
+							"description": "The individual's forename",
+							"type": "string",
+							"maxLength": 50
+						},
+						"secondName": {
+							"description": "The individual's second name",
+							"type": "string",
+							"maxLength": 50
+						},
+						"thirdName": {
+							"description": "The individual's third name",
+							"type": "string",
+							"maxLength": 50
+						},
+						"lastName": {
+							"description": "The individual's surname",
+							"type": "string",
+							"maxLength": 50
+						}
+					},
+					"additionalProperties": false
+				},
+				"driverNumber": {
+					"description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
+					"type": "string",
+					"maxLength": 24
+				},
+				"dateOfBirth": {
+					"description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+					"type": "string",
+					"minLength": 10,
+					"maxLength": 10
+				},
+				"gender": {
+					"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+					"type": "string",
+					"enum": [
+						"M",
+						"F"
+					]
+				},
+				"candidateAddress": {
+					"description": "Details of the address",
+					"type": "object",
+					"properties": {
+						"addressLine1": {
+							"description": "First line of address",
+							"type": "string",
+							"maxLength": 255
+						},
+						"addressLine2": {
+							"description": "Second line of address",
+							"type": "string",
+							"maxLength": 100
+						},
+						"addressLine3": {
+							"description": "Third line of address",
+							"type": "string",
+							"maxLength": 100
+						},
+						"addressLine4": {
+							"description": "Fourth line of address",
+							"type": "string",
+							"maxLength": 100
+						},
+						"addressLine5": {
+							"description": "Fifth line of address",
+							"type": "string",
+							"maxLength": 255
+						},
+						"postcode": {
+							"description": "The address postcode",
+							"type": "string",
+							"maxLength": 255
+						}
+					},
+					"additionalProperties": false
+				},
+				"primaryTelephone": {
+					"description": "The candidate's primary telephone number, if any (and consent to leave voicemail has been given)",
+					"type": "string",
+					"maxLength": 20
+				},
+				"secondaryTelephone": {
+					"description": "The candidate's secondary telephone number, if any (and consent to leave voicemail has been given)",
+					"type": "string",
+					"maxLength": 20
+				},
+				"mobileTelephone": {
+					"description": "The candidate's mobile telephone number, if any (and consent to leave voicemail has been given)",
+					"type": "string",
+					"maxLength": 30
+				},
+				"emailAddress": {
+					"description": "The candidate's email address, if any",
+					"type": "string",
+					"maxLength": 100
+				},
+				"prn": {
+					"description": "The candidate's ADI PRN (potential register number), if an ADI test",
+					"type": "integer"
+				},
+				"previousADITests": {
+					"description": "The number of previous test attempts, if an ADI test",
+					"type": "integer"
+				},
+				"ethnicityCode": {
+					"description": "A character between A and G representing different categories of ethnicity",
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 1
+				}
+			},
+			"additionalProperties": false
+		},
+		"applicationReference": {
+			"description": "The full application identifier, including applicationId, bookingSequence and checkDigit",
+			"type": "object",
+			"properties": {
+				"applicationId": {
+					"description": "Unique identifier for each test application",
+					"type": "integer"
+				},
+				"bookingSequence": {
+					"description": "Booking sequence number of the test application",
+					"type": "integer"
+				},
+				"checkDigit": {
+					"description": "Reference checksum for the test application",
+					"type": "integer"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"applicationId",
+				"bookingSequence",
+				"checkDigit"
+			]
+		},
+		"initiator": {
+			"description": "The reason for the previous test cancellation",
+			"type": "string",
+			"enum": [
+				"Act of nature",
+				"DSA"
+			],
+			"maxLength": 15
+		},
+		"testSlotAttributes": {
+			"description": "The additional attributes of the test slot such as Slot Id, Category, Start Time, etc.",
+			"type": "object",
+			"properties": {
+				"slotId": {
+					"description": "Unique identifier for the journal test slot",
+					"type": "integer"
+				},
+				"start": {
+					"description": "Start time of the test slot",
+					"type": "string",
+					"minLength": 19,
+					"maxLength": 19
+				},
+				"vehicleTypeCode": {
+					"description": "A short alpha (and sometimes numeric) code describing the vehicle type in vehicle slot type",
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 2
+				},
+				"welshTest": {
+					"description": "Whether the test is to be conducted using the welsh language",
+					"type": "boolean"
+				},
+				"specialNeedsCode": {
+					"description": "Special needs code",
+					"type": "string",
+					"enum": [
+						"NONE",
+						"YES",
+						"EXTRA"
+					]
+				},
+				"specialNeeds": {
+					"description": "Whether the candidate has any special needs that require the D255 form to be completed",
+					"type": "boolean"
+				},
+				"specialNeedsArray": {
+					"description": "The special needs",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"extendedTest": {
+					"description": "Whether this is an extended test",
+					"type": "boolean"
+				},
+				"examinerVisiting": {
+					"description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
+					"type": "boolean"
+				},
+				"entitlementCheck": {
+					"description": "Indicates whether the examiner needs to check the candidates entitlement evidence(e.g. test application has not been checked with DVLA)",
+					"type": "boolean"
+				},
+				"previousCancellation": {
+					"description": "The details of any previous test cancellations",
+					"type": "array",
+					"items": {
+						"description": "The reason for the previous test cancellation",
+						"type": "string",
+						"enum": [
+							"Act of nature",
+							"DSA"
+						],
+						"maxLength": 15
+					}
+				},
+				"slotType": {
+					"description": "A description of the types of test intended to be conducted in this slot (e.g. Standard Test / Extended Special Needs Test)",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"slotId",
+				"start",
+				"vehicleTypeCode",
+				"welshTest",
+				"specialNeeds",
+				"extendedTest"
+			]
+		},
+		"journalData": {
+			"description": "Data brought through from the journal",
+			"type": "object",
+			"properties": {
+				"examiner": {
+					"description": "The examiner details",
+					"type": "object",
+					"properties": {
+						"staffNumber": {
+							"description": "The examiner's DSA staff number",
+							"type": "string",
+							"maxLength": 10
+						},
+						"individualId": {
+							"description": "The individual ID of the examiner",
+							"type": "number"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"staffNumber"
+					]
+				},
+				"testCentre": {
+					"description": "Details of the test centre",
+					"type": "object",
+					"properties": {
+						"centreId": {
+							"description": "Identifer for the test centre",
+							"type": "integer"
+						},
+						"costCode": {
+							"description": "Cost centre code for the test centre",
+							"type": "string",
+							"maxLength": 6
+						},
+						"centreName": {
+							"description": "Name of the test centre",
+							"type": "string",
+							"maxLength": 50
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"centreId",
+						"costCode"
+					]
+				},
+				"testSlotAttributes": {
+					"description": "The additional attributes of the test slot such as Slot Id, Category, Start Time, etc.",
+					"type": "object",
+					"properties": {
+						"slotId": {
+							"description": "Unique identifier for the journal test slot",
+							"type": "integer"
+						},
+						"start": {
+							"description": "Start time of the test slot",
+							"type": "string",
+							"minLength": 19,
+							"maxLength": 19
+						},
+						"vehicleTypeCode": {
+							"description": "A short alpha (and sometimes numeric) code describing the vehicle type in vehicle slot type",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 2
+						},
+						"welshTest": {
+							"description": "Whether the test is to be conducted using the welsh language",
+							"type": "boolean"
+						},
+						"specialNeedsCode": {
+							"description": "Special needs code",
+							"type": "string",
+							"enum": [
+								"NONE",
+								"YES",
+								"EXTRA"
+							]
+						},
+						"specialNeeds": {
+							"description": "Whether the candidate has any special needs that require the D255 form to be completed",
+							"type": "boolean"
+						},
+						"specialNeedsArray": {
+							"description": "The special needs",
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						},
+						"extendedTest": {
+							"description": "Whether this is an extended test",
+							"type": "boolean"
+						},
+						"examinerVisiting": {
+							"description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
+							"type": "boolean"
+						},
+						"entitlementCheck": {
+							"description": "Indicates whether the examiner needs to check the candidates entitlement evidence(e.g. test application has not been checked with DVLA)",
+							"type": "boolean"
+						},
+						"previousCancellation": {
+							"description": "The details of any previous test cancellations",
+							"type": "array",
+							"items": {
+								"description": "The reason for the previous test cancellation",
+								"type": "string",
+								"enum": [
+									"Act of nature",
+									"DSA"
+								],
+								"maxLength": 15
+							}
+						},
+						"slotType": {
+							"description": "A description of the types of test intended to be conducted in this slot (e.g. Standard Test / Extended Special Needs Test)",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"slotId",
+						"start",
+						"vehicleTypeCode",
+						"welshTest",
+						"specialNeeds",
+						"extendedTest"
+					]
+				},
+				"candidate": {
+					"description": "Details of the candidate booked into the test slot",
+					"type": "object",
+					"properties": {
+						"candidateId": {
+							"description": "The id of the test candidate",
+							"type": "integer"
+						},
+						"candidateName": {
+							"description": "Details of the individual's name",
+							"type": "object",
+							"properties": {
+								"title": {
+									"description": "The individual's title",
+									"type": "string",
+									"maxLength": 7
+								},
+								"firstName": {
+									"description": "The individual's forename",
+									"type": "string",
+									"maxLength": 50
+								},
+								"secondName": {
+									"description": "The individual's second name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"thirdName": {
+									"description": "The individual's third name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"lastName": {
+									"description": "The individual's surname",
+									"type": "string",
+									"maxLength": 50
+								}
+							},
+							"additionalProperties": false
+						},
+						"driverNumber": {
+							"description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
+							"type": "string",
+							"maxLength": 24
+						},
+						"dateOfBirth": {
+							"description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+							"type": "string",
+							"minLength": 10,
+							"maxLength": 10
+						},
+						"gender": {
+							"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+							"type": "string",
+							"enum": [
+								"M",
+								"F"
+							]
+						},
+						"candidateAddress": {
+							"description": "Details of the address",
+							"type": "object",
+							"properties": {
+								"addressLine1": {
+									"description": "First line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"addressLine2": {
+									"description": "Second line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine3": {
+									"description": "Third line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine4": {
+									"description": "Fourth line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine5": {
+									"description": "Fifth line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"postcode": {
+									"description": "The address postcode",
+									"type": "string",
+									"maxLength": 255
+								}
+							},
+							"additionalProperties": false
+						},
+						"primaryTelephone": {
+							"description": "The candidate's primary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"secondaryTelephone": {
+							"description": "The candidate's secondary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"mobileTelephone": {
+							"description": "The candidate's mobile telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 30
+						},
+						"emailAddress": {
+							"description": "The candidate's email address, if any",
+							"type": "string",
+							"maxLength": 100
+						},
+						"prn": {
+							"description": "The candidate's ADI PRN (potential register number), if an ADI test",
+							"type": "integer"
+						},
+						"previousADITests": {
+							"description": "The number of previous test attempts, if an ADI test",
+							"type": "integer"
+						},
+						"ethnicityCode": {
+							"description": "A character between A and G representing different categories of ethnicity",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 1
+						}
+					},
+					"additionalProperties": false
+				},
+				"applicationReference": {
+					"description": "The full application identifier, including applicationId, bookingSequence and checkDigit",
+					"type": "object",
+					"properties": {
+						"applicationId": {
+							"description": "Unique identifier for each test application",
+							"type": "integer"
+						},
+						"bookingSequence": {
+							"description": "Booking sequence number of the test application",
+							"type": "integer"
+						},
+						"checkDigit": {
+							"description": "Reference checksum for the test application",
+							"type": "integer"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"applicationId",
+						"bookingSequence",
+						"checkDigit"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"examiner",
+				"testCentre",
+				"testSlotAttributes",
+				"candidate",
+				"applicationReference"
+			]
+		},
+		"signature": {
+			"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+			"type": "string"
+		},
+		"communicationMethod": {
+			"description": "The method of communication by which the candidate agrees to receive their results",
+			"type": "string",
+			"enum": [
+				"Email",
+				"Post",
+				"Support Centre",
+				"Not provided"
+			]
+		},
+		"conductedLanguage": {
+			"description": "The language in which a candidate agrees to perform a test",
+			"type": "string",
+			"enum": [
+				"English",
+				"Cymraeg",
+				"Not provided"
+			]
+		},
+		"communicationPreferences": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"updatedEmail": {
+					"description": "The email address that the candidate agrees their results can be sent to",
+					"type": "string",
+					"maxLength": 100
+				},
+				"communicationMethod": {
+					"description": "The method of communication by which the candidate agrees to receive their results",
+					"type": "string",
+					"enum": [
+						"Email",
+						"Post",
+						"Support Centre",
+						"Not provided"
+					]
+				},
+				"conductedLanguage": {
+					"description": "The language in which a candidate agrees to perform a test",
+					"type": "string",
+					"enum": [
+						"English",
+						"Cymraeg",
+						"Not provided"
+					]
+				}
+			},
+			"required": [
+				"updatedEmail",
+				"communicationMethod",
+				"conductedLanguage"
+			]
+		},
+		"preTestDeclarations": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"insuranceDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
+					"type": "boolean"
+				},
+				"residencyDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
+					"type": "boolean"
+				},
+				"preTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				},
+				"DL196CBTCertNumber": {
+					"description": "The number of the DL196 CBT certificate presented by the candidate",
+					"type": "string"
+				}
+			},
+			"required": [
+				"insuranceDeclarationAccepted",
+				"residencyDeclarationAccepted",
+				"preTestSignature"
+			]
+		},
+		"accompaniment": {
+			"description": "Indicators for anybody else overseeing the test",
+			"type": "object",
+			"properties": {
+				"ADI": {
+					"description": "Indicates whether the ADI was present during the test",
+					"type": "boolean"
+				},
+				"supervisor": {
+					"description": "Indicates whether a DVSA supervisor was present during the test",
+					"type": "boolean"
+				},
+				"interpreter": {
+					"description": "Indicates whether an interpreter was present during the test",
+					"type": "boolean"
+				},
+				"other": {
+					"description": "Indicates whether another individual was present during the test",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"gearboxCategory": {
+			"description": "The type of gearbox",
+			"type": "string",
+			"enum": [
+				"Manual",
+				"Automatic"
+			]
+		},
+		"drivingFaultCount": {
+			"description": "The count of the number of driving faults recorded against a test element",
+			"type": "integer"
+		},
+		"faultComments": {
+			"description": "Comments recorded against a fault",
+			"type": "string",
+			"maxLength": 1000
+		},
+		"drivingFaults": {
+			"description": "The driving faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"precautions": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"precautionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"seriousFaultIndicator": {
+			"description": "Indicator for a serious fault being recorded against a test element",
+			"type": "boolean"
+		},
+		"seriousFaults": {
+			"description": "The serious faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"precautions": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"precautionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"dangerousFaultIndicator": {
+			"description": "Indicator for a dangerous fault being recorded against a test element",
+			"type": "boolean"
+		},
+		"dangerousFaults": {
+			"description": "The dangerous faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"precautions": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"precautionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"postTestDeclarations": {
+			"type": "object",
+			"properties": {
+				"healthDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their health status hasn't changed since their last application",
+					"type": "boolean"
+				},
+				"passCertificateNumberReceived": {
+					"description": "Indicates whether the candidate acknowledges receipt of the PCN",
+					"type": "boolean"
+				},
+				"postTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"weatherConditions": {
+			"description": "Predefined values for the type of weather encountered during the test",
+			"type": "string",
+			"enum": [
+				"Bright / dry roads",
+				"Bright / wet roads",
+				"Raining through test",
+				"Showers",
+				"Foggy / misty",
+				"Dull / wet roads",
+				"Dull / dry roads",
+				"Snowing",
+				"Icy",
+				"Windy"
+			]
+		},
+		"identification": {
+			"description": "Indicates which form of ID was provided by the candidate",
+			"type": "string",
+			"enum": [
+				"Licence",
+				"Passport"
+			]
+		},
+		"testSummary": {
+			"description": "Recording of other characteristics of the test",
+			"type": "object",
+			"properties": {
+				"routeNumber": {
+					"description": "Number of the route that was taken during the test",
+					"type": "integer",
+					"const": 88
+				},
+				"candidateDescription": {
+					"description": "Physical description of the candidate",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"debriefWitnessed": {
+					"description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
+					"type": "boolean"
+				},
+				"identification": {
+					"description": "Indicates which form of ID was provided by the candidate",
+					"type": "string",
+					"enum": [
+						"Licence",
+						"Passport"
+					]
+				},
+				"weatherConditions": {
+					"description": "Description of the type of weather encountered during the test",
+					"type": "array",
+					"items": {
+						"description": "Predefined values for the type of weather encountered during the test",
+						"type": "string",
+						"enum": [
+							"Bright / dry roads",
+							"Bright / wet roads",
+							"Raining through test",
+							"Showers",
+							"Foggy / misty",
+							"Dull / wet roads",
+							"Dull / dry roads",
+							"Snowing",
+							"Icy",
+							"Windy"
+						]
+					}
+				},
+				"D255": {
+					"description": "Indicates whether a D255 form needs to be completed",
+					"type": "boolean"
+				},
+				"additionalInformation": {
+					"description": "Any comments that the DE wants to record about the test",
+					"type": "string"
+				},
+				"circuit": {
+					"description": "Circuit completed (left or right)",
+					"type": "string",
+					"enum": [
+						"Left",
+						"Right"
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"categoryCode": {
+			"description": "Category code for the test report",
+			"type": "string",
+			"enum": [
+				"A",
+				"A1",
+				"A2",
+				"ADI2",
+				"ADI3",
+				"AM",
+				"B",
+				"B1",
+				"B+E",
+				"C",
+				"C1",
+				"C1+E",
+				"CCPC",
+				"C+E",
+				"D",
+				"D1",
+				"D1+E",
+				"DCPC",
+				"D+E",
+				"EUA1M1",
+				"EUA1M2",
+				"EUA2M1",
+				"EUA2M2",
+				"EUAM1",
+				"EUAM2",
+				"EUAMM1",
+				"EUAMM2",
+				"F",
+				"G",
+				"H",
+				"K",
+				"SC"
+			]
+		},
+		"activityCode": {
+			"description": "Code representing the result of the test",
+			"type": "string",
+			"enum": [
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"11",
+				"20",
+				"21",
+				"22",
+				"23",
+				"24",
+				"25",
+				"26",
+				"27",
+				"28",
+				"32",
+				"33",
+				"34",
+				"35",
+				"36",
+				"37",
+				"38",
+				"40",
+				"41",
+				"51",
+				"52",
+				"55",
+				"58",
+				"59",
+				"60",
+				"61",
+				"62",
+				"63",
+				"64",
+				"66",
+				"67",
+				"68",
+				"69",
+				"70",
+				"71",
+				"73",
+				"74",
+				"75",
+				"82",
+				"83"
+			]
+		},
+		"gender": {
+			"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+			"type": "string",
+			"enum": [
+				"M",
+				"F"
+			]
+		},
+		"rekeyReason": {
+			"description": "Recording of the rekey reason",
+			"type": "object",
+			"properties": {
+				"transfer": {
+					"description": "Recording of if a rekey was due to a transfer",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"ipadIssue": {
+					"description": "Recording of if a rekey was due to a iPad issue",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"technicalFault": {
+							"description": "If the iPad was not used due to a technical fault",
+							"type": "boolean"
+						},
+						"lost": {
+							"description": "If the iPad was not used as it has been lost",
+							"type": "boolean"
+						},
+						"stolen": {
+							"description": "If the iPad was not used as it has been stolen",
+							"type": "boolean"
+						},
+						"broken": {
+							"description": "If the iPad was not used as it is broken",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"other": {
+					"description": "Recording of if a rekey was due to a different reason",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"reason": {
+							"description": "The reason this option was selected",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"transfer": {
+			"description": "Recording of if a rekey was due to a transfer",
+			"type": "object",
+			"properties": {
+				"selected": {
+					"description": "If this option was selected",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"ipadIssue": {
+			"description": "Recording of if a rekey was due to a iPad issue",
+			"type": "object",
+			"properties": {
+				"selected": {
+					"description": "If this option was selected",
+					"type": "boolean"
+				},
+				"technicalFault": {
+					"description": "If the iPad was not used due to a technical fault",
+					"type": "boolean"
+				},
+				"lost": {
+					"description": "If the iPad was not used as it has been lost",
+					"type": "boolean"
+				},
+				"stolen": {
+					"description": "If the iPad was not used as it has been stolen",
+					"type": "boolean"
+				},
+				"broken": {
+					"description": "If the iPad was not used as it is broken",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"other": {
+			"description": "Recording of if a rekey was due to a different reason",
+			"type": "object",
+			"properties": {
+				"selected": {
+					"description": "If this option was selected",
+					"type": "boolean"
+				},
+				"reason": {
+					"description": "The reason this option was selected",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"vehicleDetails": {
+			"description": "Details about the vehicle to be used for the test",
+			"type": "object",
+			"properties": {
+				"registrationNumber": {
+					"description": "The vehicle registration number",
+					"type": "string",
+					"maxLength": 7
+				},
+				"gearboxCategory": {
+					"description": "The type of gearbox",
+					"type": "string",
+					"enum": [
+						"Manual",
+						"Automatic"
+					]
+				},
+				"schoolBike": {
+					"description": "Indicates whether the bike belongs to a driving school",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"passCompletion": {
+			"description": "Finalisation of a successful test outcome",
+			"type": "object",
+			"properties": {
+				"provisionalLicenceProvided": {
+					"description": "Indicates whether the candidate submitted their provisional driving licence",
+					"type": "boolean"
+				},
+				"passCertificateNumber": {
+					"description": "The PCN issued to the candidate",
+					"type": "string",
+					"maxLength": 8,
+					"minLength": 8
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"provisionalLicenceProvided",
+				"passCertificateNumber"
+			]
+		},
+		"DL196CBTCertNumber": {
+			"description": "The number of the DL196 CBT certificate presented by the candidate",
+			"type": "string"
+		},
+		"avoidance": {
+			"description": "The outcome of avoidance tests",
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"firstAttempt": {
+					"description": "The speed of the first attempt",
+					"type": "integer"
+				},
+				"secondAttempt": {
+					"description": "The speed of the second attempt",
+					"type": "integer"
+				},
+				"speedNotMetSeriousFault": {
+					"description": "Whether the required speed was not met",
+					"type": "boolean"
+				},
+				"outcome": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				}
+			}
+		},
+		"emergencyStop": {
+			"description": "The outcome of emergency stop tests",
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"firstAttempt": {
+					"description": "The speed of the first attempt",
+					"type": "integer"
+				},
+				"secondAttempt": {
+					"description": "The speed of the second attempt",
+					"type": "integer"
+				},
+				"speedNotMetSeriousFault": {
+					"description": "Whether the required speed was not met",
+					"type": "boolean"
+				},
+				"outcome": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				}
+			}
+		},
+		"ETA": {
+			"description": "Indicates whether the examiner had to take physical or verbal action during the test",
+			"type": "object",
+			"properties": {
+				"physical": {
+					"description": "Indicates that the examiner had to take physical action",
+					"type": "boolean"
+				},
+				"verbal": {
+					"description": "Indicates that the examiner had to take verbal action",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"schoolBike": {
+			"description": "Indicates whether the bike belongs to a driving school",
+			"type": "boolean"
+		},
+		"businessName": {
+			"description": "Name of the business the candidate relates to",
+			"type": "string",
+			"maxLength": 100
+		},
+		"businessTelephone": {
+			"description": "Telephone number of the business the candidate relates to",
+			"type": "string",
+			"maxLength": 20
+		}
+	},
+	"properties": {
+		"version": {
+			"description": "Version number",
+			"type": "string"
+		},
+		"category": {
+			"description": "Category code for the test report",
+			"type": "string",
+			"enum": [
+				"A",
+				"A1",
+				"A2",
+				"ADI2",
+				"ADI3",
+				"AM",
+				"B",
+				"B1",
+				"B+E",
+				"C",
+				"C1",
+				"C1+E",
+				"CCPC",
+				"C+E",
+				"D",
+				"D1",
+				"D1+E",
+				"DCPC",
+				"D+E",
+				"EUA1M1",
+				"EUA1M2",
+				"EUA2M1",
+				"EUA2M2",
+				"EUAM1",
+				"EUAM2",
+				"EUAMM1",
+				"EUAMM2",
+				"F",
+				"G",
+				"H",
+				"K",
+				"SC"
+			]
+		},
+		"journalData": {
+			"description": "Data brought through from the journal",
+			"type": "object",
+			"properties": {
+				"examiner": {
+					"description": "The examiner details",
+					"type": "object",
+					"properties": {
+						"staffNumber": {
+							"description": "The examiner's DSA staff number",
+							"type": "string",
+							"maxLength": 10
+						},
+						"individualId": {
+							"description": "The individual ID of the examiner",
+							"type": "number"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"staffNumber"
+					]
+				},
+				"testCentre": {
+					"description": "Details of the test centre",
+					"type": "object",
+					"properties": {
+						"centreId": {
+							"description": "Identifer for the test centre",
+							"type": "integer"
+						},
+						"costCode": {
+							"description": "Cost centre code for the test centre",
+							"type": "string",
+							"maxLength": 6
+						},
+						"centreName": {
+							"description": "Name of the test centre",
+							"type": "string",
+							"maxLength": 50
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"centreId",
+						"costCode"
+					]
+				},
+				"testSlotAttributes": {
+					"description": "The additional attributes of the test slot such as Slot Id, Category, Start Time, etc.",
+					"type": "object",
+					"properties": {
+						"slotId": {
+							"description": "Unique identifier for the journal test slot",
+							"type": "integer"
+						},
+						"start": {
+							"description": "Start time of the test slot",
+							"type": "string",
+							"minLength": 19,
+							"maxLength": 19
+						},
+						"vehicleTypeCode": {
+							"description": "A short alpha (and sometimes numeric) code describing the vehicle type in vehicle slot type",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 2
+						},
+						"welshTest": {
+							"description": "Whether the test is to be conducted using the welsh language",
+							"type": "boolean"
+						},
+						"specialNeedsCode": {
+							"description": "Special needs code",
+							"type": "string",
+							"enum": [
+								"NONE",
+								"YES",
+								"EXTRA"
+							]
+						},
+						"specialNeeds": {
+							"description": "Whether the candidate has any special needs that require the D255 form to be completed",
+							"type": "boolean"
+						},
+						"specialNeedsArray": {
+							"description": "The special needs",
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						},
+						"extendedTest": {
+							"description": "Whether this is an extended test",
+							"type": "boolean"
+						},
+						"examinerVisiting": {
+							"description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
+							"type": "boolean"
+						},
+						"entitlementCheck": {
+							"description": "Indicates whether the examiner needs to check the candidates entitlement evidence(e.g. test application has not been checked with DVLA)",
+							"type": "boolean"
+						},
+						"previousCancellation": {
+							"description": "The details of any previous test cancellations",
+							"type": "array",
+							"items": {
+								"description": "The reason for the previous test cancellation",
+								"type": "string",
+								"enum": [
+									"Act of nature",
+									"DSA"
+								],
+								"maxLength": 15
+							}
+						},
+						"slotType": {
+							"description": "A description of the types of test intended to be conducted in this slot (e.g. Standard Test / Extended Special Needs Test)",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"slotId",
+						"start",
+						"vehicleTypeCode",
+						"welshTest",
+						"specialNeeds",
+						"extendedTest"
+					]
+				},
+				"candidate": {
+					"description": "Details of the candidate booked into the test slot",
+					"type": "object",
+					"properties": {
+						"candidateId": {
+							"description": "The id of the test candidate",
+							"type": "integer"
+						},
+						"candidateName": {
+							"description": "Details of the individual's name",
+							"type": "object",
+							"properties": {
+								"title": {
+									"description": "The individual's title",
+									"type": "string",
+									"maxLength": 7
+								},
+								"firstName": {
+									"description": "The individual's forename",
+									"type": "string",
+									"maxLength": 50
+								},
+								"secondName": {
+									"description": "The individual's second name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"thirdName": {
+									"description": "The individual's third name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"lastName": {
+									"description": "The individual's surname",
+									"type": "string",
+									"maxLength": 50
+								}
+							},
+							"additionalProperties": false
+						},
+						"driverNumber": {
+							"description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
+							"type": "string",
+							"maxLength": 24
+						},
+						"dateOfBirth": {
+							"description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+							"type": "string",
+							"minLength": 10,
+							"maxLength": 10
+						},
+						"gender": {
+							"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+							"type": "string",
+							"enum": [
+								"M",
+								"F"
+							]
+						},
+						"candidateAddress": {
+							"description": "Details of the address",
+							"type": "object",
+							"properties": {
+								"addressLine1": {
+									"description": "First line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"addressLine2": {
+									"description": "Second line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine3": {
+									"description": "Third line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine4": {
+									"description": "Fourth line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine5": {
+									"description": "Fifth line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"postcode": {
+									"description": "The address postcode",
+									"type": "string",
+									"maxLength": 255
+								}
+							},
+							"additionalProperties": false
+						},
+						"primaryTelephone": {
+							"description": "The candidate's primary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"secondaryTelephone": {
+							"description": "The candidate's secondary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"mobileTelephone": {
+							"description": "The candidate's mobile telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 30
+						},
+						"emailAddress": {
+							"description": "The candidate's email address, if any",
+							"type": "string",
+							"maxLength": 100
+						},
+						"prn": {
+							"description": "The candidate's ADI PRN (potential register number), if an ADI test",
+							"type": "integer"
+						},
+						"previousADITests": {
+							"description": "The number of previous test attempts, if an ADI test",
+							"type": "integer"
+						},
+						"ethnicityCode": {
+							"description": "A character between A and G representing different categories of ethnicity",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 1
+						}
+					},
+					"additionalProperties": false
+				},
+				"applicationReference": {
+					"description": "The full application identifier, including applicationId, bookingSequence and checkDigit",
+					"type": "object",
+					"properties": {
+						"applicationId": {
+							"description": "Unique identifier for each test application",
+							"type": "integer"
+						},
+						"bookingSequence": {
+							"description": "Booking sequence number of the test application",
+							"type": "integer"
+						},
+						"checkDigit": {
+							"description": "Reference checksum for the test application",
+							"type": "integer"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"applicationId",
+						"bookingSequence",
+						"checkDigit"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"examiner",
+				"testCentre",
+				"testSlotAttributes",
+				"candidate",
+				"applicationReference"
+			]
+		},
+		"activityCode": {
+			"description": "Code representing the result of the test",
+			"type": "string",
+			"enum": [
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"11",
+				"20",
+				"21",
+				"22",
+				"23",
+				"24",
+				"25",
+				"26",
+				"27",
+				"28",
+				"32",
+				"33",
+				"34",
+				"35",
+				"36",
+				"37",
+				"38",
+				"40",
+				"41",
+				"51",
+				"52",
+				"55",
+				"58",
+				"59",
+				"60",
+				"61",
+				"62",
+				"63",
+				"64",
+				"66",
+				"67",
+				"68",
+				"69",
+				"70",
+				"71",
+				"73",
+				"74",
+				"75",
+				"82",
+				"83"
+			]
+		},
+		"communicationPreferences": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"updatedEmail": {
+					"description": "The email address that the candidate agrees their results can be sent to",
+					"type": "string",
+					"maxLength": 100
+				},
+				"communicationMethod": {
+					"description": "The method of communication by which the candidate agrees to receive their results",
+					"type": "string",
+					"enum": [
+						"Email",
+						"Post",
+						"Support Centre",
+						"Not provided"
+					]
+				},
+				"conductedLanguage": {
+					"description": "The language in which a candidate agrees to perform a test",
+					"type": "string",
+					"enum": [
+						"English",
+						"Cymraeg",
+						"Not provided"
+					]
+				}
+			},
+			"required": [
+				"updatedEmail",
+				"communicationMethod",
+				"conductedLanguage"
+			]
+		},
+		"preTestDeclarations": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"insuranceDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
+					"type": "boolean"
+				},
+				"residencyDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
+					"type": "boolean"
+				},
+				"preTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				},
+				"DL196CBTCertNumber": {
+					"description": "The number of the DL196 CBT certificate presented by the candidate",
+					"type": "string"
+				}
+			},
+			"required": [
+				"insuranceDeclarationAccepted",
+				"residencyDeclarationAccepted",
+				"preTestSignature"
+			]
+		},
+		"accompaniment": {
+			"description": "Indicators for anybody else overseeing the test",
+			"type": "object",
+			"properties": {
+				"ADI": {
+					"description": "Indicates whether the ADI was present during the test",
+					"type": "boolean"
+				},
+				"supervisor": {
+					"description": "Indicates whether a DVSA supervisor was present during the test",
+					"type": "boolean"
+				},
+				"interpreter": {
+					"description": "Indicates whether an interpreter was present during the test",
+					"type": "boolean"
+				},
+				"other": {
+					"description": "Indicates whether another individual was present during the test",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"postTestDeclarations": {
+			"type": "object",
+			"properties": {
+				"healthDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their health status hasn't changed since their last application",
+					"type": "boolean"
+				},
+				"passCertificateNumberReceived": {
+					"description": "Indicates whether the candidate acknowledges receipt of the PCN",
+					"type": "boolean"
+				},
+				"postTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"testSummary": {
+			"description": "Recording of other characteristics of the test",
+			"type": "object",
+			"properties": {
+				"routeNumber": {
+					"description": "Number of the route that was taken during the test",
+					"type": "integer",
+					"const": 88
+				},
+				"candidateDescription": {
+					"description": "Physical description of the candidate",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"debriefWitnessed": {
+					"description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
+					"type": "boolean"
+				},
+				"identification": {
+					"description": "Indicates which form of ID was provided by the candidate",
+					"type": "string",
+					"enum": [
+						"Licence",
+						"Passport"
+					]
+				},
+				"weatherConditions": {
+					"description": "Description of the type of weather encountered during the test",
+					"type": "array",
+					"items": {
+						"description": "Predefined values for the type of weather encountered during the test",
+						"type": "string",
+						"enum": [
+							"Bright / dry roads",
+							"Bright / wet roads",
+							"Raining through test",
+							"Showers",
+							"Foggy / misty",
+							"Dull / wet roads",
+							"Dull / dry roads",
+							"Snowing",
+							"Icy",
+							"Windy"
+						]
+					}
+				},
+				"D255": {
+					"description": "Indicates whether a D255 form needs to be completed",
+					"type": "boolean"
+				},
+				"additionalInformation": {
+					"description": "Any comments that the DE wants to record about the test",
+					"type": "string"
+				},
+				"circuit": {
+					"description": "Circuit completed (left or right)",
+					"type": "string",
+					"enum": [
+						"Left",
+						"Right"
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"rekeyReason": {
+			"description": "Recording of the rekey reason",
+			"type": "object",
+			"properties": {
+				"transfer": {
+					"description": "Recording of if a rekey was due to a transfer",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"ipadIssue": {
+					"description": "Recording of if a rekey was due to a iPad issue",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"technicalFault": {
+							"description": "If the iPad was not used due to a technical fault",
+							"type": "boolean"
+						},
+						"lost": {
+							"description": "If the iPad was not used as it has been lost",
+							"type": "boolean"
+						},
+						"stolen": {
+							"description": "If the iPad was not used as it has been stolen",
+							"type": "boolean"
+						},
+						"broken": {
+							"description": "If the iPad was not used as it is broken",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"other": {
+					"description": "Recording of if a rekey was due to a different reason",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"reason": {
+							"description": "The reason this option was selected",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"rekey": {
+			"description": "Whether the test was rekeyed or not",
+			"type": "boolean"
+		},
+		"rekeyDate": {
+			"description": "Date the test was rekeyed",
+			"type": "string"
+		},
+		"changeMarker": {
+			"description": "Whether the test was conducted by another examiner",
+			"type": "boolean"
+		},
+		"examinerBooked": {
+			"description": "The examiner who the test was booked to",
+			"type": "number"
+		},
+		"examinerConducted": {
+			"description": "The examiner who conducted the test",
+			"type": "number"
+		},
+		"examinerKeyed": {
+			"description": "The examiner who keyed the test into the iPad",
+			"type": "number"
+		},
+		"passCompletion": {
+			"description": "Finalisation of a successful test outcome",
+			"type": "object",
+			"properties": {
+				"provisionalLicenceProvided": {
+					"description": "Indicates whether the candidate submitted their provisional driving licence",
+					"type": "boolean"
+				},
+				"passCertificateNumber": {
+					"description": "The PCN issued to the candidate",
+					"type": "string",
+					"maxLength": 8,
+					"minLength": 8
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"provisionalLicenceProvided",
+				"passCertificateNumber"
+			]
+		},
+		"vehicleDetails": {
+			"description": "Details about the vehicle to be used for the test",
+			"type": "object",
+			"properties": {
+				"registrationNumber": {
+					"description": "The vehicle registration number",
+					"type": "string",
+					"maxLength": 7
+				},
+				"gearboxCategory": {
+					"description": "The type of gearbox",
+					"type": "string",
+					"enum": [
+						"Manual",
+						"Automatic"
+					]
+				},
+				"schoolBike": {
+					"description": "Indicates whether the bike belongs to a driving school",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"testData": {
+			"additionalProperties": false,
+			"description": "Data associated with the test",
+			"properties": {
+				"useOfStand": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"manualHandling": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slalom": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slowControl": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"uTurn": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"controlledStop": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"emergencyStop": {
+					"description": "The outcome of emergency stop tests",
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"firstAttempt": {
+							"description": "The speed of the first attempt",
+							"type": "integer"
+						},
+						"secondAttempt": {
+							"description": "The speed of the second attempt",
+							"type": "integer"
+						},
+						"speedNotMetSeriousFault": {
+							"description": "Whether the required speed was not met",
+							"type": "boolean"
+						},
+						"outcome": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						}
+					}
+				},
+				"avoidance": {
+					"description": "The outcome of avoidance tests",
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"firstAttempt": {
+							"description": "The speed of the first attempt",
+							"type": "integer"
+						},
+						"secondAttempt": {
+							"description": "The speed of the second attempt",
+							"type": "integer"
+						},
+						"speedNotMetSeriousFault": {
+							"description": "Whether the required speed was not met",
+							"type": "boolean"
+						},
+						"outcome": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						}
+					}
+				},
+				"drivingFaults": {
+					"description": "The driving faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"seriousFaults": {
+					"description": "The serious faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"dangerousFaults": {
+					"description": "The dangerous faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"precautions": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"precautionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"ETA": {
+					"description": "Indicates whether the examiner had to take physical or verbal action during the test",
+					"type": "object",
+					"properties": {
+						"physical": {
+							"description": "Indicates that the examiner had to take physical action",
+							"type": "boolean"
+						},
+						"verbal": {
+							"description": "Indicates that the examiner had to take verbal action",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"type": "object"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"version",
+		"category",
+		"journalData",
+		"activityCode",
+		"rekey",
+		"changeMarker",
+		"examinerBooked",
+		"examinerConducted",
+		"examinerKeyed",
+		"journalData"
+	]
 }

--- a/mes-test-schema/categories/AM2/index.json
+++ b/mes-test-schema/categories/AM2/index.json
@@ -1,1055 +1,5093 @@
 {
-  "title": "Test Result Cat AM2 Schema",
-  "type": "object",
-  "definitions": {
-    "gearboxCategory": {
-      "$ref": "../common/index.json#/definitions/gearboxCategory"
-    },
-    "eyesightTest": {
-      "$ref": "../common/index.json#/definitions/eyesightTest"
-    },
-    "circuit": {
-      "description": "Circuit completed (left or right)",
-      "type": "string",
-      "enum": [
-        "Left",
-        "Right"
-      ]
-    },
-    "independentDriving": {
-      "$ref": "../common/index.json#/definitions/independentDriving"
-    },
-    "identification": {
-      "$ref": "../common/index.json#/definitions/identification"
-    },
-    "weatherConditions": {
-      "$ref": "../common/index.json#/definitions/weatherConditions"
-    },
-    "signature": {
-      "$ref": "../common/index.json#/definitions/signature"
-    },
-    "journalData": {
-      "$ref": "../common/index.json#/definitions/journalData"
-    },
-    "activityCode": {
-      "$ref": "../common/index.json#/definitions/activityCode"
-    },
-    "communicationPreferences": {
-      "$ref": "../common/index.json#/definitions/communicationPreferences"
-    },
-    "preTestDeclarations": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "insuranceDeclarationAccepted": {
-          "description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
-          "type": "boolean"
-        },
-        "residencyDeclarationAccepted": {
-          "description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
-          "type": "boolean"
-        },
-        "preTestSignature": {
-          "$ref": "#/definitions/signature"
-        },
-        "DL196CBTCertNumber": {
-          "$ref": "#/definitions/DL196CBTCertNumber"
-        }
-      },
-      "required": [
-        "insuranceDeclarationAccepted",
-        "residencyDeclarationAccepted",
-        "preTestSignature",
-        "mod1CertificateNumber"
-      ]
-    },
-    "accompaniment": {
-      "$ref": "../common/index.json#/definitions/accompaniment"
-    },
-    "postTestDeclarations": {
-      "$ref": "../common/index.json#/definitions/postTestDeclarations"
-    },
-    "testSummary": {
-      "description": "Recording of other characteristics of the test",
-      "type": "object",
-      "properties": {
-        "routeNumber": {
-          "description": "Number of the route that was taken during the test",
-          "type": "integer",
-          "const": 88
-        },
-        "independentDriving": {
-          "$ref": "#/definitions/independentDriving"
-        },
-        "candidateDescription": {
-          "description": "Physical description of the candidate",
-          "type": "string",
-          "maxLength": 1000
-        },
-        "debriefWitnessed": {
-          "description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
-          "type": "boolean"
-        },
-        "identification": {
-          "$ref": "#/definitions/identification"
-        },
-        "weatherConditions": {
-          "description": "Description of the type of weather encountered during the test",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/weatherConditions"
-          }
-        },
-        "D255": {
-          "description": "Indicates whether a D255 form needs to be completed",
-          "type": "boolean"
-        },
-        "additionalInformation": {
-          "description": "Any comments that the DE wants to record about the test",
-          "type": "string"
-        },
-        "circuit": {
-          "$ref": "#/definitions/circuit"
-        }
-      },
-      "additionalProperties": false
-    },
-    "rekeyReason": {
-      "$ref": "../common/index.json#/definitions/rekeyReason"
-    },
-    "passCompletion": {
-      "description": "Finalisation of a successful test outcome",
-      "type": "object",
-      "properties": {
-        "provisionalLicenceProvided": {
-          "description": "Indicates whether the candidate submitted their provisional driving licence",
-          "type": "boolean"
-        },
-        "passCertificateNumber": {
-          "description": "The PCN issued to the candidate",
-          "type": "string",
-          "maxLength": 8,
-          "minLength": 8
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "provisionalLicenceProvided",
-        "passCertificateNumber"
-      ]
-    },
-    "categoryCode": {
-      "$ref": "../common/index.json#/definitions/categoryCode"
-    },
-    "faultComments": {
-      "$ref": "../common/index.json#/definitions/faultComments"
-    },
-    "drivingFaultCount": {
-      "$ref": "../common/index.json#/definitions/drivingFaultCount"
-    },
-    "ETA": {
-      "description": "Indicates whether the examiner had to take verbal action during the test",
-      "type": "object",
-      "properties": {
-        "verbal": {
-          "description": "Indicates that the examiner had to take verbal action",
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "eco": {
-      "$ref": "../common/index.json#/definitions/eco"
-    },
-    "drivingFaults": {
-      "description": "The driving faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "controlsThrottle": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsThrottleComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsClutch": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsClutchComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsGears": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsGearsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsFrontbrake": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsFrontbrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsRearBrake": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsRearBrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsSteering": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "controlsSteeringComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "ancillaryControls": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "ancillaryControlsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsSignalling": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "useOfMirrorsSignallingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeDirection": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "useOfMirrorsChangeDirectionComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeSpeed": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "useOfMirrorsChangeSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsNecessary": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "signalsNecessaryComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsCorrectly": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "signalsCorrectlyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsTimed": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "signalsTimedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsApproachSpeed": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "junctionsApproachSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsObservation": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "junctionsObservationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningRight": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "junctionsTurningRightComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningLeft": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "junctionsTurningLeftComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsCuttingCorners": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "junctionsCuttingCornersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementOvertaking": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "judgementOvertakingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementMeeting": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "judgementMeetingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementCrossing": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "judgementCrossingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningNormalDriving": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "positioningNormalDrivingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningLaneDiscipline": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "positioningLaneDisciplineComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "clearanceOrObstructions": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "clearanceOrObstructionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "followingDistance": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "followingDistanceComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfSpeed": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "useOfSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressAppropriateSpeed": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "progressAppropriateSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressUndueHesitation": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "progressUndueHesitationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficSigns": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "responseToSignsTrafficSignsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsRoadMarkings": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "responseToSignsRoadMarkingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficLights": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "responseToSignsTrafficLightsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficControllers": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "responseToSignsTrafficControllersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsOtherRoadUsers": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "responseToSignsOtherRoadUsersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "pedestrianCrossings": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "pedestrianCrossingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positionNormalStops": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "positionNormalStopsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "awarenessPlanning": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "awarenessPlanningComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "bends": {
-          "$ref": "#/definitions/drivingFaultCount"
-        },
-        "bendsComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "seriousFaultIndicator": {
-      "description": "Indicator for a serious fault being recorded against a test element",
-      "type": "boolean"
-    },
-    "seriousFaults": {
-      "description": "The serious faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "controlsThrottle": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsThrottleComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsClutch": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsClutchComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsGears": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsGearsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsFrontbrake": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsFrontbrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsRearBrake": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsRearBrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsSteering": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "controlsSteeringComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "ancillaryControls": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "ancillaryControlsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsSignalling": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "useOfMirrorsSignallingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeDirection": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "useOfMirrorsChangeDirectionComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeSpeed": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "useOfMirrorsChangeSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsNecessary": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "signalsNecessaryComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsCorrectly": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "signalsCorrectlyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsTimed": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "signalsTimedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsApproachSpeed": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "junctionsApproachSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsObservation": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "junctionsObservationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningRight": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "junctionsTurningRightComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningLeft": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "junctionsTurningLeftComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsCuttingCorners": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "junctionsCuttingCornersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementOvertaking": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "judgementOvertakingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementMeeting": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "judgementMeetingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementCrossing": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "judgementCrossingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningNormalDriving": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "positioningNormalDrivingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningLaneDiscipline": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "positioningLaneDisciplineComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "clearanceOrObstructions": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "clearanceOrObstructionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "followingDistance": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "followingDistanceComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfSpeed": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "useOfSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressAppropriateSpeed": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "progressAppropriateSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressUndueHesitation": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "progressUndueHesitationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficSigns": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "responseToSignsTrafficSignsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsRoadMarkings": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "responseToSignsRoadMarkingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficLights": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "responseToSignsTrafficLightsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficControllers": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "responseToSignsTrafficControllersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsOtherRoadUsers": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "responseToSignsOtherRoadUsersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "pedestrianCrossings": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "pedestrianCrossingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positionNormalStops": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "positionNormalStopsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "awarenessPlanning": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "awarenessPlanningComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "bends": {
-          "$ref": "#/definitions/seriousFaultIndicator"
-        },
-        "bendsComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "dangerousFaults": {
-      "description": "The dangerous faults accumulated during the test",
-      "type": "object",
-      "properties": {
-        "controlsThrottle": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsThrottleComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsClutch": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsClutchComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsGears": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsGearsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsFrontbrake": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsFrontbrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsRearBrake": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsRearBrakeComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "controlsSteering": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "controlsSteeringComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "ancillaryControls": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "ancillaryControlsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffSafety": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "moveOffSafetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "moveOffControl": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "moveOffControlComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsSignalling": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "useOfMirrorsSignallingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeDirection": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "useOfMirrorsChangeDirectionComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfMirrorsChangeSpeed": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "useOfMirrorsChangeSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsNecessary": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "signalsNecessaryComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsCorrectly": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "signalsCorrectlyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "signalsTimed": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "signalsTimedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsApproachSpeed": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "junctionsApproachSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsObservation": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "junctionsObservationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningRight": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "junctionsTurningRightComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsTurningLeft": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "junctionsTurningLeftComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "junctionsCuttingCorners": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "junctionsCuttingCornersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementOvertaking": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "judgementOvertakingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementMeeting": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "judgementMeetingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "judgementCrossing": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "judgementCrossingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningNormalDriving": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "positioningNormalDrivingComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positioningLaneDiscipline": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "positioningLaneDisciplineComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "clearanceOrObstructions": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "clearanceOrObstructionsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "followingDistance": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "followingDistanceComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "useOfSpeed": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "useOfSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressAppropriateSpeed": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "progressAppropriateSpeedComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "progressUndueHesitation": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "progressUndueHesitationComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficSigns": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "responseToSignsTrafficSignsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsRoadMarkings": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "responseToSignsRoadMarkingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficLights": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "responseToSignsTrafficLightsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsTrafficControllers": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "responseToSignsTrafficControllersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "responseToSignsOtherRoadUsers": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "responseToSignsOtherRoadUsersComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "pedestrianCrossings": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "pedestrianCrossingsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "positionNormalStops": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "positionNormalStopsComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "awarenessPlanning": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "awarenessPlanningComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "bends": {
-          "$ref": "#/definitions/dangerousFaultIndicator"
-        },
-        "bendsComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "additionalProperties": false
-    },
-    "dangerousFaultIndicator": {
-      "description": "Indicator for a dangerous fault being recorded against a test element",
-      "type": "boolean"
-    },
-    "schoolBike": {
-      "description": "Indicates whether the bike belongs to a driving school",
-      "type": "boolean"
-    },
-    "questionResult": {
-      "$ref": "../common/index.json#/definitions/questionResult"
-    },
-    "vehicleDetails": {
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "schoolBike": {
-          "$ref": "#/definitions/schoolBike"
-        },
-        "gearboxCategory": {
-          "$ref": "#/definitions/gearboxCategory"
-        },
-        "registrationNumber": {
-          "description": "The vehicle registration number",
-          "type": "string",
-          "maxLength": 7
-        }
-      }
-    },
-    "safetyAndBalanceQuestions": {
-      "additionalProperties": false,
-      "description": "Details of the safety and balance questions asked during the test",
-      "properties": {
-        "safetyQuestions": {
-          "items": {
-            "$ref": "#/definitions/questionResult"
-          },
-          "type": "array"
-        },
-        "safetyComments": {
-          "$ref": "#/definitions/faultComments"
-        },
-        "balanceQuestions": {
-          "items": {
-            "$ref": "#/definitions/questionResult"
-          },
-          "type": "array"
-        },
-        "balanceComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "type": "object"
-    },
-    "testData": {
-      "description": "Data associated with the test",
-      "type": "object",
-      "properties": {
-        "ETA": {
-          "$ref": "#/definitions/ETA"
-        },
-        "drivingFaults": {
-          "$ref": "#/definitions/drivingFaults"
-        },
-        "seriousFaults": {
-          "$ref": "#/definitions/seriousFaults"
-        },
-        "dangerousFaults": {
-          "$ref": "#/definitions/dangerousFaults"
-        },
-        "safetyAndBalanceQuestions": {
-          "$ref": "#/definitions/safetyAndBalanceQuestions"
-        },
-        "eco": {
-          "$ref": "#/definitions/eco"
-        },
-        "eyesightTest": {
-          "$ref": "#/definitions/eyesightTest"
-        }
-      },
-      "additionalProperties": false
-    },
-    "DL196CBTCertNumber": {
-      "description": "The number of the DL196 CBT certificate presented by the candidate",
-      "type": "string"
-    }
-  },
-  "properties": {
-    "version": {
-      "description": "Version number",
-      "type": "string"
-    },
-    "category": {
-      "$ref": "#/definitions/categoryCode"
-    },
-    "journalData": {
-      "$ref": "#/definitions/journalData"
-    },
-    "activityCode": {
-      "$ref": "#/definitions/activityCode"
-    },
-    "communicationPreferences": {
-      "$ref": "#/definitions/communicationPreferences"
-    },
-    "preTestDeclarations": {
-      "$ref": "#/definitions/preTestDeclarations"
-    },
-    "accompaniment": {
-      "$ref": "#/definitions/accompaniment"
-    },
-    "postTestDeclarations": {
-      "$ref": "#/definitions/postTestDeclarations"
-    },
-    "testSummary": {
-      "$ref": "#/definitions/testSummary"
-    },
-    "rekeyReason": {
-      "$ref": "#/definitions/rekeyReason"
-    },
-    "rekey": {
-      "description": "Whether the test was rekeyed or not",
-      "type": "boolean"
-    },
-    "rekeyDate": {
-      "description": "Date the test was rekeyed",
-      "type": "string"
-    },
-    "changeMarker": {
-      "description": "Whether the test was conducted by another examiner",
-      "type": "boolean"
-    },
-    "examinerBooked": {
-      "description": "The examiner who the test was booked to",
-      "type": "number"
-    },
-    "examinerConducted": {
-      "description": "The examiner who conducted the test",
-      "type": "number"
-    },
-    "examinerKeyed": {
-      "description": "The examiner who keyed the test into the iPad",
-      "type": "number"
-    },
-    "passCompletion": {
-      "$ref": "#/definitions/passCompletion"
-    },
-    "vehicleDetails": {
-      "$ref": "#/definitions/vehicleDetails"
-    },
-    "testData": {
-      "$ref": "#/definitions/testData"
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "version",
-    "category",
-    "journalData",
-    "activityCode",
-    "rekey",
-    "changeMarker",
-    "examinerBooked",
-    "examinerConducted",
-    "examinerKeyed"
-  ]
+	"title": "Test Result Cat AM2 Schema",
+	"type": "object",
+	"definitions": {
+		"gearboxCategory": {
+			"description": "The type of gearbox",
+			"type": "string",
+			"enum": [
+				"Manual",
+				"Automatic"
+			]
+		},
+		"eyesightTest": {
+			"type": "object",
+			"properties": {
+				"complete": {
+					"type": "boolean"
+				},
+				"seriousFault": {
+					"description": "Whether the candidate has failed the eyesight test",
+					"type": "boolean"
+				},
+				"faultComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"circuit": {
+			"description": "Circuit completed (left or right)",
+			"type": "string",
+			"enum": [
+				"Left",
+				"Right"
+			]
+		},
+		"independentDriving": {
+			"description": "Method chosen to conduct the independent driving section of the test",
+			"type": "string",
+			"enum": [
+				"Sat nav",
+				"Diagram",
+				"Traffic signs",
+				"N/A"
+			]
+		},
+		"identification": {
+			"description": "Indicates which form of ID was provided by the candidate",
+			"type": "string",
+			"enum": [
+				"Licence",
+				"Passport"
+			]
+		},
+		"weatherConditions": {
+			"description": "Predefined values for the type of weather encountered during the test",
+			"type": "string",
+			"enum": [
+				"Bright / dry roads",
+				"Bright / wet roads",
+				"Raining through test",
+				"Showers",
+				"Foggy / misty",
+				"Dull / wet roads",
+				"Dull / dry roads",
+				"Snowing",
+				"Icy",
+				"Windy"
+			]
+		},
+		"signature": {
+			"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+			"type": "string"
+		},
+		"journalData": {
+			"description": "Data brought through from the journal",
+			"type": "object",
+			"properties": {
+				"examiner": {
+					"description": "The examiner details",
+					"type": "object",
+					"properties": {
+						"staffNumber": {
+							"description": "The examiner's DSA staff number",
+							"type": "string",
+							"maxLength": 10
+						},
+						"individualId": {
+							"description": "The individual ID of the examiner",
+							"type": "number"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"staffNumber"
+					]
+				},
+				"testCentre": {
+					"description": "Details of the test centre",
+					"type": "object",
+					"properties": {
+						"centreId": {
+							"description": "Identifer for the test centre",
+							"type": "integer"
+						},
+						"costCode": {
+							"description": "Cost centre code for the test centre",
+							"type": "string",
+							"maxLength": 6
+						},
+						"centreName": {
+							"description": "Name of the test centre",
+							"type": "string",
+							"maxLength": 50
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"centreId",
+						"costCode"
+					]
+				},
+				"testSlotAttributes": {
+					"description": "The additional attributes of the test slot such as Slot Id, Category, Start Time, etc.",
+					"type": "object",
+					"properties": {
+						"slotId": {
+							"description": "Unique identifier for the journal test slot",
+							"type": "integer"
+						},
+						"start": {
+							"description": "Start time of the test slot",
+							"type": "string",
+							"minLength": 19,
+							"maxLength": 19
+						},
+						"vehicleTypeCode": {
+							"description": "A short alpha (and sometimes numeric) code describing the vehicle type in vehicle slot type",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 2
+						},
+						"welshTest": {
+							"description": "Whether the test is to be conducted using the welsh language",
+							"type": "boolean"
+						},
+						"specialNeedsCode": {
+							"description": "Special needs code",
+							"type": "string",
+							"enum": [
+								"NONE",
+								"YES",
+								"EXTRA"
+							]
+						},
+						"specialNeeds": {
+							"description": "Whether the candidate has any special needs that require the D255 form to be completed",
+							"type": "boolean"
+						},
+						"specialNeedsArray": {
+							"description": "The special needs",
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						},
+						"extendedTest": {
+							"description": "Whether this is an extended test",
+							"type": "boolean"
+						},
+						"examinerVisiting": {
+							"description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
+							"type": "boolean"
+						},
+						"entitlementCheck": {
+							"description": "Indicates whether the examiner needs to check the candidates entitlement evidence(e.g. test application has not been checked with DVLA)",
+							"type": "boolean"
+						},
+						"previousCancellation": {
+							"description": "The details of any previous test cancellations",
+							"type": "array",
+							"items": {
+								"description": "The reason for the previous test cancellation",
+								"type": "string",
+								"enum": [
+									"Act of nature",
+									"DSA"
+								],
+								"maxLength": 15
+							}
+						},
+						"slotType": {
+							"description": "A description of the types of test intended to be conducted in this slot (e.g. Standard Test / Extended Special Needs Test)",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"slotId",
+						"start",
+						"vehicleTypeCode",
+						"welshTest",
+						"specialNeeds",
+						"extendedTest"
+					]
+				},
+				"candidate": {
+					"description": "Details of the candidate booked into the test slot",
+					"type": "object",
+					"properties": {
+						"candidateId": {
+							"description": "The id of the test candidate",
+							"type": "integer"
+						},
+						"candidateName": {
+							"description": "Details of the individual's name",
+							"type": "object",
+							"properties": {
+								"title": {
+									"description": "The individual's title",
+									"type": "string",
+									"maxLength": 7
+								},
+								"firstName": {
+									"description": "The individual's forename",
+									"type": "string",
+									"maxLength": 50
+								},
+								"secondName": {
+									"description": "The individual's second name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"thirdName": {
+									"description": "The individual's third name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"lastName": {
+									"description": "The individual's surname",
+									"type": "string",
+									"maxLength": 50
+								}
+							},
+							"additionalProperties": false
+						},
+						"driverNumber": {
+							"description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
+							"type": "string",
+							"maxLength": 24
+						},
+						"dateOfBirth": {
+							"description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+							"type": "string",
+							"minLength": 10,
+							"maxLength": 10
+						},
+						"gender": {
+							"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+							"type": "string",
+							"enum": [
+								"M",
+								"F"
+							]
+						},
+						"candidateAddress": {
+							"description": "Details of the address",
+							"type": "object",
+							"properties": {
+								"addressLine1": {
+									"description": "First line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"addressLine2": {
+									"description": "Second line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine3": {
+									"description": "Third line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine4": {
+									"description": "Fourth line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine5": {
+									"description": "Fifth line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"postcode": {
+									"description": "The address postcode",
+									"type": "string",
+									"maxLength": 255
+								}
+							},
+							"additionalProperties": false
+						},
+						"primaryTelephone": {
+							"description": "The candidate's primary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"secondaryTelephone": {
+							"description": "The candidate's secondary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"mobileTelephone": {
+							"description": "The candidate's mobile telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 30
+						},
+						"emailAddress": {
+							"description": "The candidate's email address, if any",
+							"type": "string",
+							"maxLength": 100
+						},
+						"prn": {
+							"description": "The candidate's ADI PRN (potential register number), if an ADI test",
+							"type": "integer"
+						},
+						"previousADITests": {
+							"description": "The number of previous test attempts, if an ADI test",
+							"type": "integer"
+						},
+						"ethnicityCode": {
+							"description": "A character between A and G representing different categories of ethnicity",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 1
+						}
+					},
+					"additionalProperties": false
+				},
+				"applicationReference": {
+					"description": "The full application identifier, including applicationId, bookingSequence and checkDigit",
+					"type": "object",
+					"properties": {
+						"applicationId": {
+							"description": "Unique identifier for each test application",
+							"type": "integer"
+						},
+						"bookingSequence": {
+							"description": "Booking sequence number of the test application",
+							"type": "integer"
+						},
+						"checkDigit": {
+							"description": "Reference checksum for the test application",
+							"type": "integer"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"applicationId",
+						"bookingSequence",
+						"checkDigit"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"examiner",
+				"testCentre",
+				"testSlotAttributes",
+				"candidate",
+				"applicationReference"
+			]
+		},
+		"activityCode": {
+			"description": "Code representing the result of the test",
+			"type": "string",
+			"enum": [
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"11",
+				"20",
+				"21",
+				"22",
+				"23",
+				"24",
+				"25",
+				"26",
+				"27",
+				"28",
+				"32",
+				"33",
+				"34",
+				"35",
+				"36",
+				"37",
+				"38",
+				"40",
+				"41",
+				"51",
+				"52",
+				"55",
+				"58",
+				"59",
+				"60",
+				"61",
+				"62",
+				"63",
+				"64",
+				"66",
+				"67",
+				"68",
+				"69",
+				"70",
+				"71",
+				"73",
+				"74",
+				"75",
+				"82",
+				"83"
+			]
+		},
+		"communicationPreferences": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"updatedEmail": {
+					"description": "The email address that the candidate agrees their results can be sent to",
+					"type": "string",
+					"maxLength": 100
+				},
+				"communicationMethod": {
+					"description": "The method of communication by which the candidate agrees to receive their results",
+					"type": "string",
+					"enum": [
+						"Email",
+						"Post",
+						"Support Centre",
+						"Not provided"
+					]
+				},
+				"conductedLanguage": {
+					"description": "The language in which a candidate agrees to perform a test",
+					"type": "string",
+					"enum": [
+						"English",
+						"Cymraeg",
+						"Not provided"
+					]
+				}
+			},
+			"required": [
+				"updatedEmail",
+				"communicationMethod",
+				"conductedLanguage"
+			]
+		},
+		"preTestDeclarations": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"insuranceDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
+					"type": "boolean"
+				},
+				"residencyDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
+					"type": "boolean"
+				},
+				"preTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				},
+				"DL196CBTCertNumber": {
+					"description": "The number of the DL196 CBT certificate presented by the candidate",
+					"type": "string"
+				}
+			},
+			"required": [
+				"insuranceDeclarationAccepted",
+				"residencyDeclarationAccepted",
+				"preTestSignature",
+				"mod1CertificateNumber"
+			]
+		},
+		"accompaniment": {
+			"description": "Indicators for anybody else overseeing the test",
+			"type": "object",
+			"properties": {
+				"ADI": {
+					"description": "Indicates whether the ADI was present during the test",
+					"type": "boolean"
+				},
+				"supervisor": {
+					"description": "Indicates whether a DVSA supervisor was present during the test",
+					"type": "boolean"
+				},
+				"interpreter": {
+					"description": "Indicates whether an interpreter was present during the test",
+					"type": "boolean"
+				},
+				"other": {
+					"description": "Indicates whether another individual was present during the test",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"postTestDeclarations": {
+			"type": "object",
+			"properties": {
+				"healthDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their health status hasn't changed since their last application",
+					"type": "boolean"
+				},
+				"passCertificateNumberReceived": {
+					"description": "Indicates whether the candidate acknowledges receipt of the PCN",
+					"type": "boolean"
+				},
+				"postTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"testSummary": {
+			"description": "Recording of other characteristics of the test",
+			"type": "object",
+			"properties": {
+				"routeNumber": {
+					"description": "Number of the route that was taken during the test",
+					"type": "integer",
+					"const": 88
+				},
+				"independentDriving": {
+					"description": "Method chosen to conduct the independent driving section of the test",
+					"type": "string",
+					"enum": [
+						"Sat nav",
+						"Diagram",
+						"Traffic signs",
+						"N/A"
+					]
+				},
+				"candidateDescription": {
+					"description": "Physical description of the candidate",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"debriefWitnessed": {
+					"description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
+					"type": "boolean"
+				},
+				"identification": {
+					"description": "Indicates which form of ID was provided by the candidate",
+					"type": "string",
+					"enum": [
+						"Licence",
+						"Passport"
+					]
+				},
+				"weatherConditions": {
+					"description": "Description of the type of weather encountered during the test",
+					"type": "array",
+					"items": {
+						"description": "Predefined values for the type of weather encountered during the test",
+						"type": "string",
+						"enum": [
+							"Bright / dry roads",
+							"Bright / wet roads",
+							"Raining through test",
+							"Showers",
+							"Foggy / misty",
+							"Dull / wet roads",
+							"Dull / dry roads",
+							"Snowing",
+							"Icy",
+							"Windy"
+						]
+					}
+				},
+				"D255": {
+					"description": "Indicates whether a D255 form needs to be completed",
+					"type": "boolean"
+				},
+				"additionalInformation": {
+					"description": "Any comments that the DE wants to record about the test",
+					"type": "string"
+				},
+				"circuit": {
+					"description": "Circuit completed (left or right)",
+					"type": "string",
+					"enum": [
+						"Left",
+						"Right"
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"rekeyReason": {
+			"description": "Recording of the rekey reason",
+			"type": "object",
+			"properties": {
+				"transfer": {
+					"description": "Recording of if a rekey was due to a transfer",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"ipadIssue": {
+					"description": "Recording of if a rekey was due to a iPad issue",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"technicalFault": {
+							"description": "If the iPad was not used due to a technical fault",
+							"type": "boolean"
+						},
+						"lost": {
+							"description": "If the iPad was not used as it has been lost",
+							"type": "boolean"
+						},
+						"stolen": {
+							"description": "If the iPad was not used as it has been stolen",
+							"type": "boolean"
+						},
+						"broken": {
+							"description": "If the iPad was not used as it is broken",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"other": {
+					"description": "Recording of if a rekey was due to a different reason",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"reason": {
+							"description": "The reason this option was selected",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"passCompletion": {
+			"description": "Finalisation of a successful test outcome",
+			"type": "object",
+			"properties": {
+				"provisionalLicenceProvided": {
+					"description": "Indicates whether the candidate submitted their provisional driving licence",
+					"type": "boolean"
+				},
+				"passCertificateNumber": {
+					"description": "The PCN issued to the candidate",
+					"type": "string",
+					"maxLength": 8,
+					"minLength": 8
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"provisionalLicenceProvided",
+				"passCertificateNumber"
+			]
+		},
+		"categoryCode": {
+			"description": "Category code for the test report",
+			"type": "string",
+			"enum": [
+				"A",
+				"A1",
+				"A2",
+				"ADI2",
+				"ADI3",
+				"AM",
+				"B",
+				"B1",
+				"B+E",
+				"C",
+				"C1",
+				"C1+E",
+				"CCPC",
+				"C+E",
+				"D",
+				"D1",
+				"D1+E",
+				"DCPC",
+				"D+E",
+				"EUA1M1",
+				"EUA1M2",
+				"EUA2M1",
+				"EUA2M2",
+				"EUAM1",
+				"EUAM2",
+				"EUAMM1",
+				"EUAMM2",
+				"F",
+				"G",
+				"H",
+				"K",
+				"SC"
+			]
+		},
+		"faultComments": {
+			"description": "Comments recorded against a fault",
+			"type": "string",
+			"maxLength": 1000
+		},
+		"drivingFaultCount": {
+			"description": "The count of the number of driving faults recorded against a test element",
+			"type": "integer"
+		},
+		"ETA": {
+			"description": "Indicates whether the examiner had to take verbal action during the test",
+			"type": "object",
+			"properties": {
+				"verbal": {
+					"description": "Indicates that the examiner had to take verbal action",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"eco": {
+			"description": "Assessment of the eco friendly manner of driving",
+			"type": "object",
+			"properties": {
+				"completed": {
+					"description": "Indicates that the eco friendly manner of driving has been assessed",
+					"type": "boolean"
+				},
+				"adviceGivenControl": {
+					"description": "Indicates that advice was given on the Control aspect of eco driving",
+					"type": "boolean"
+				},
+				"adviceGivenPlanning": {
+					"description": "Indicates that advice was given on the Planning aspect of eco driving",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"drivingFaults": {
+			"description": "The driving faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"controlsThrottle": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsThrottleComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsClutch": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsClutchComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsGears": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsGearsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsFrontbrake": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsFrontbrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsRearBrake": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsRearBrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsSteering": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"controlsSteeringComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"ancillaryControls": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"ancillaryControlsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsSignalling": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"useOfMirrorsSignallingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeDirection": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"useOfMirrorsChangeDirectionComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeSpeed": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"useOfMirrorsChangeSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsNecessary": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"signalsNecessaryComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsCorrectly": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"signalsCorrectlyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsTimed": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"signalsTimedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsApproachSpeed": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"junctionsApproachSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsObservation": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"junctionsObservationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningRight": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"junctionsTurningRightComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningLeft": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"junctionsTurningLeftComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsCuttingCorners": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"junctionsCuttingCornersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementOvertaking": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"judgementOvertakingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementMeeting": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"judgementMeetingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementCrossing": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"judgementCrossingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningNormalDriving": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"positioningNormalDrivingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningLaneDiscipline": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"positioningLaneDisciplineComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"clearanceOrObstructions": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"clearanceOrObstructionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"followingDistance": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"followingDistanceComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfSpeed": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"useOfSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressAppropriateSpeed": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"progressAppropriateSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressUndueHesitation": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"progressUndueHesitationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficSigns": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"responseToSignsTrafficSignsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsRoadMarkings": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"responseToSignsRoadMarkingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficLights": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"responseToSignsTrafficLightsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficControllers": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"responseToSignsTrafficControllersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsOtherRoadUsers": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"responseToSignsOtherRoadUsersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"pedestrianCrossings": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"pedestrianCrossingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positionNormalStops": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"positionNormalStopsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"awarenessPlanning": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"awarenessPlanningComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"bends": {
+					"description": "The count of the number of driving faults recorded against a test element",
+					"type": "integer"
+				},
+				"bendsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"seriousFaultIndicator": {
+			"description": "Indicator for a serious fault being recorded against a test element",
+			"type": "boolean"
+		},
+		"seriousFaults": {
+			"description": "The serious faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"controlsThrottle": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsThrottleComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsClutch": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsClutchComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsGears": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsGearsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsFrontbrake": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsFrontbrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsRearBrake": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsRearBrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsSteering": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsSteeringComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"ancillaryControls": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"ancillaryControlsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsSignalling": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsSignallingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeDirection": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsChangeDirectionComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeSpeed": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsChangeSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsNecessary": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsNecessaryComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsCorrectly": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsCorrectlyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsTimed": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsTimedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsApproachSpeed": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsApproachSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsObservation": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsObservationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningRight": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsTurningRightComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningLeft": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsTurningLeftComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsCuttingCorners": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsCuttingCornersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementOvertaking": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementOvertakingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementMeeting": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementMeetingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementCrossing": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementCrossingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningNormalDriving": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positioningNormalDrivingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningLaneDiscipline": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positioningLaneDisciplineComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"clearanceOrObstructions": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"clearanceOrObstructionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"followingDistance": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"followingDistanceComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfSpeed": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressAppropriateSpeed": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"progressAppropriateSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressUndueHesitation": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"progressUndueHesitationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficSigns": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficSignsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsRoadMarkings": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsRoadMarkingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficLights": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficLightsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficControllers": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficControllersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsOtherRoadUsers": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsOtherRoadUsersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"pedestrianCrossings": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"pedestrianCrossingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positionNormalStops": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positionNormalStopsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"awarenessPlanning": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"awarenessPlanningComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"bends": {
+					"description": "Indicator for a serious fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"bendsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"dangerousFaults": {
+			"description": "The dangerous faults accumulated during the test",
+			"type": "object",
+			"properties": {
+				"controlsThrottle": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsThrottleComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsClutch": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsClutchComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsGears": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsGearsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsFrontbrake": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsFrontbrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsRearBrake": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsRearBrakeComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlsSteering": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"controlsSteeringComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"ancillaryControls": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"ancillaryControlsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffSafety": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffSafetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"moveOffControl": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"moveOffControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsSignalling": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsSignallingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeDirection": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsChangeDirectionComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfMirrorsChangeSpeed": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfMirrorsChangeSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsNecessary": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsNecessaryComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsCorrectly": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsCorrectlyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"signalsTimed": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"signalsTimedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsApproachSpeed": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsApproachSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsObservation": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsObservationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningRight": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsTurningRightComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsTurningLeft": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsTurningLeftComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"junctionsCuttingCorners": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"junctionsCuttingCornersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementOvertaking": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementOvertakingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementMeeting": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementMeetingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"judgementCrossing": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"judgementCrossingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningNormalDriving": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positioningNormalDrivingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positioningLaneDiscipline": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positioningLaneDisciplineComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"clearanceOrObstructions": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"clearanceOrObstructionsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"followingDistance": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"followingDistanceComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"useOfSpeed": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"useOfSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressAppropriateSpeed": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"progressAppropriateSpeedComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"progressUndueHesitation": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"progressUndueHesitationComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficSigns": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficSignsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsRoadMarkings": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsRoadMarkingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficLights": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficLightsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsTrafficControllers": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsTrafficControllersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"responseToSignsOtherRoadUsers": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"responseToSignsOtherRoadUsersComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"pedestrianCrossings": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"pedestrianCrossingsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"positionNormalStops": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"positionNormalStopsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"awarenessPlanning": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"awarenessPlanningComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"bends": {
+					"description": "Indicator for a dangerous fault being recorded against a test element",
+					"type": "boolean"
+				},
+				"bendsComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"additionalProperties": false
+		},
+		"dangerousFaultIndicator": {
+			"description": "Indicator for a dangerous fault being recorded against a test element",
+			"type": "boolean"
+		},
+		"schoolBike": {
+			"description": "Indicates whether the bike belongs to a driving school",
+			"type": "boolean"
+		},
+		"questionResult": {
+			"description": "Result of a vehicle checks question",
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"code": {
+					"description": "Code representing the question that was asked",
+					"type": "string"
+				},
+				"description": {
+					"description": "Description of the question that was asked",
+					"type": "string"
+				},
+				"outcome": {
+					"description": "Outcome of the question that was asked",
+					"type": "string",
+					"enum": [
+						"P",
+						"DF",
+						"S",
+						"D"
+					]
+				}
+			}
+		},
+		"vehicleDetails": {
+			"additionalProperties": false,
+			"type": "object",
+			"properties": {
+				"schoolBike": {
+					"description": "Indicates whether the bike belongs to a driving school",
+					"type": "boolean"
+				},
+				"gearboxCategory": {
+					"description": "The type of gearbox",
+					"type": "string",
+					"enum": [
+						"Manual",
+						"Automatic"
+					]
+				},
+				"registrationNumber": {
+					"description": "The vehicle registration number",
+					"type": "string",
+					"maxLength": 7
+				}
+			}
+		},
+		"safetyAndBalanceQuestions": {
+			"additionalProperties": false,
+			"description": "Details of the safety and balance questions asked during the test",
+			"properties": {
+				"safetyQuestions": {
+					"items": {
+						"description": "Result of a vehicle checks question",
+						"type": "object",
+						"additionalProperties": false,
+						"properties": {
+							"code": {
+								"description": "Code representing the question that was asked",
+								"type": "string"
+							},
+							"description": {
+								"description": "Description of the question that was asked",
+								"type": "string"
+							},
+							"outcome": {
+								"description": "Outcome of the question that was asked",
+								"type": "string",
+								"enum": [
+									"P",
+									"DF",
+									"S",
+									"D"
+								]
+							}
+						}
+					},
+					"type": "array"
+				},
+				"safetyComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"balanceQuestions": {
+					"items": {
+						"description": "Result of a vehicle checks question",
+						"type": "object",
+						"additionalProperties": false,
+						"properties": {
+							"code": {
+								"description": "Code representing the question that was asked",
+								"type": "string"
+							},
+							"description": {
+								"description": "Description of the question that was asked",
+								"type": "string"
+							},
+							"outcome": {
+								"description": "Outcome of the question that was asked",
+								"type": "string",
+								"enum": [
+									"P",
+									"DF",
+									"S",
+									"D"
+								]
+							}
+						}
+					},
+					"type": "array"
+				},
+				"balanceComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			},
+			"type": "object"
+		},
+		"testData": {
+			"description": "Data associated with the test",
+			"type": "object",
+			"properties": {
+				"ETA": {
+					"description": "Indicates whether the examiner had to take verbal action during the test",
+					"type": "object",
+					"properties": {
+						"verbal": {
+							"description": "Indicates that the examiner had to take verbal action",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"drivingFaults": {
+					"description": "The driving faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"seriousFaults": {
+					"description": "The serious faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"dangerousFaults": {
+					"description": "The dangerous faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"safetyAndBalanceQuestions": {
+					"additionalProperties": false,
+					"description": "Details of the safety and balance questions asked during the test",
+					"properties": {
+						"safetyQuestions": {
+							"items": {
+								"description": "Result of a vehicle checks question",
+								"type": "object",
+								"additionalProperties": false,
+								"properties": {
+									"code": {
+										"description": "Code representing the question that was asked",
+										"type": "string"
+									},
+									"description": {
+										"description": "Description of the question that was asked",
+										"type": "string"
+									},
+									"outcome": {
+										"description": "Outcome of the question that was asked",
+										"type": "string",
+										"enum": [
+											"P",
+											"DF",
+											"S",
+											"D"
+										]
+									}
+								}
+							},
+							"type": "array"
+						},
+						"safetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"balanceQuestions": {
+							"items": {
+								"description": "Result of a vehicle checks question",
+								"type": "object",
+								"additionalProperties": false,
+								"properties": {
+									"code": {
+										"description": "Code representing the question that was asked",
+										"type": "string"
+									},
+									"description": {
+										"description": "Description of the question that was asked",
+										"type": "string"
+									},
+									"outcome": {
+										"description": "Outcome of the question that was asked",
+										"type": "string",
+										"enum": [
+											"P",
+											"DF",
+											"S",
+											"D"
+										]
+									}
+								}
+							},
+							"type": "array"
+						},
+						"balanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"type": "object"
+				},
+				"eco": {
+					"description": "Assessment of the eco friendly manner of driving",
+					"type": "object",
+					"properties": {
+						"completed": {
+							"description": "Indicates that the eco friendly manner of driving has been assessed",
+							"type": "boolean"
+						},
+						"adviceGivenControl": {
+							"description": "Indicates that advice was given on the Control aspect of eco driving",
+							"type": "boolean"
+						},
+						"adviceGivenPlanning": {
+							"description": "Indicates that advice was given on the Planning aspect of eco driving",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"eyesightTest": {
+					"type": "object",
+					"properties": {
+						"complete": {
+							"type": "boolean"
+						},
+						"seriousFault": {
+							"description": "Whether the candidate has failed the eyesight test",
+							"type": "boolean"
+						},
+						"faultComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"DL196CBTCertNumber": {
+			"description": "The number of the DL196 CBT certificate presented by the candidate",
+			"type": "string"
+		}
+	},
+	"properties": {
+		"version": {
+			"description": "Version number",
+			"type": "string"
+		},
+		"category": {
+			"description": "Category code for the test report",
+			"type": "string",
+			"enum": [
+				"A",
+				"A1",
+				"A2",
+				"ADI2",
+				"ADI3",
+				"AM",
+				"B",
+				"B1",
+				"B+E",
+				"C",
+				"C1",
+				"C1+E",
+				"CCPC",
+				"C+E",
+				"D",
+				"D1",
+				"D1+E",
+				"DCPC",
+				"D+E",
+				"EUA1M1",
+				"EUA1M2",
+				"EUA2M1",
+				"EUA2M2",
+				"EUAM1",
+				"EUAM2",
+				"EUAMM1",
+				"EUAMM2",
+				"F",
+				"G",
+				"H",
+				"K",
+				"SC"
+			]
+		},
+		"journalData": {
+			"description": "Data brought through from the journal",
+			"type": "object",
+			"properties": {
+				"examiner": {
+					"description": "The examiner details",
+					"type": "object",
+					"properties": {
+						"staffNumber": {
+							"description": "The examiner's DSA staff number",
+							"type": "string",
+							"maxLength": 10
+						},
+						"individualId": {
+							"description": "The individual ID of the examiner",
+							"type": "number"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"staffNumber"
+					]
+				},
+				"testCentre": {
+					"description": "Details of the test centre",
+					"type": "object",
+					"properties": {
+						"centreId": {
+							"description": "Identifer for the test centre",
+							"type": "integer"
+						},
+						"costCode": {
+							"description": "Cost centre code for the test centre",
+							"type": "string",
+							"maxLength": 6
+						},
+						"centreName": {
+							"description": "Name of the test centre",
+							"type": "string",
+							"maxLength": 50
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"centreId",
+						"costCode"
+					]
+				},
+				"testSlotAttributes": {
+					"description": "The additional attributes of the test slot such as Slot Id, Category, Start Time, etc.",
+					"type": "object",
+					"properties": {
+						"slotId": {
+							"description": "Unique identifier for the journal test slot",
+							"type": "integer"
+						},
+						"start": {
+							"description": "Start time of the test slot",
+							"type": "string",
+							"minLength": 19,
+							"maxLength": 19
+						},
+						"vehicleTypeCode": {
+							"description": "A short alpha (and sometimes numeric) code describing the vehicle type in vehicle slot type",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 2
+						},
+						"welshTest": {
+							"description": "Whether the test is to be conducted using the welsh language",
+							"type": "boolean"
+						},
+						"specialNeedsCode": {
+							"description": "Special needs code",
+							"type": "string",
+							"enum": [
+								"NONE",
+								"YES",
+								"EXTRA"
+							]
+						},
+						"specialNeeds": {
+							"description": "Whether the candidate has any special needs that require the D255 form to be completed",
+							"type": "boolean"
+						},
+						"specialNeedsArray": {
+							"description": "The special needs",
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						},
+						"extendedTest": {
+							"description": "Whether this is an extended test",
+							"type": "boolean"
+						},
+						"examinerVisiting": {
+							"description": "Whether the examiner conducting the test slot is visiting a test centre that's not their home test centre",
+							"type": "boolean"
+						},
+						"entitlementCheck": {
+							"description": "Indicates whether the examiner needs to check the candidates entitlement evidence(e.g. test application has not been checked with DVLA)",
+							"type": "boolean"
+						},
+						"previousCancellation": {
+							"description": "The details of any previous test cancellations",
+							"type": "array",
+							"items": {
+								"description": "The reason for the previous test cancellation",
+								"type": "string",
+								"enum": [
+									"Act of nature",
+									"DSA"
+								],
+								"maxLength": 15
+							}
+						},
+						"slotType": {
+							"description": "A description of the types of test intended to be conducted in this slot (e.g. Standard Test / Extended Special Needs Test)",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"slotId",
+						"start",
+						"vehicleTypeCode",
+						"welshTest",
+						"specialNeeds",
+						"extendedTest"
+					]
+				},
+				"candidate": {
+					"description": "Details of the candidate booked into the test slot",
+					"type": "object",
+					"properties": {
+						"candidateId": {
+							"description": "The id of the test candidate",
+							"type": "integer"
+						},
+						"candidateName": {
+							"description": "Details of the individual's name",
+							"type": "object",
+							"properties": {
+								"title": {
+									"description": "The individual's title",
+									"type": "string",
+									"maxLength": 7
+								},
+								"firstName": {
+									"description": "The individual's forename",
+									"type": "string",
+									"maxLength": 50
+								},
+								"secondName": {
+									"description": "The individual's second name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"thirdName": {
+									"description": "The individual's third name",
+									"type": "string",
+									"maxLength": 50
+								},
+								"lastName": {
+									"description": "The individual's surname",
+									"type": "string",
+									"maxLength": 50
+								}
+							},
+							"additionalProperties": false
+						},
+						"driverNumber": {
+							"description": "The candidate's driver number, typically (though not always) 16 characters if UK, or 8 digits if NI",
+							"type": "string",
+							"maxLength": 24
+						},
+						"dateOfBirth": {
+							"description": "The candidate's date of birth, formatted as an ISO 8601 date (YYYY-MM-DD)",
+							"type": "string",
+							"minLength": 10,
+							"maxLength": 10
+						},
+						"gender": {
+							"description": "The gender of an individual, limited to 'M' or 'F' as per TARS master data",
+							"type": "string",
+							"enum": [
+								"M",
+								"F"
+							]
+						},
+						"candidateAddress": {
+							"description": "Details of the address",
+							"type": "object",
+							"properties": {
+								"addressLine1": {
+									"description": "First line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"addressLine2": {
+									"description": "Second line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine3": {
+									"description": "Third line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine4": {
+									"description": "Fourth line of address",
+									"type": "string",
+									"maxLength": 100
+								},
+								"addressLine5": {
+									"description": "Fifth line of address",
+									"type": "string",
+									"maxLength": 255
+								},
+								"postcode": {
+									"description": "The address postcode",
+									"type": "string",
+									"maxLength": 255
+								}
+							},
+							"additionalProperties": false
+						},
+						"primaryTelephone": {
+							"description": "The candidate's primary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"secondaryTelephone": {
+							"description": "The candidate's secondary telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 20
+						},
+						"mobileTelephone": {
+							"description": "The candidate's mobile telephone number, if any (and consent to leave voicemail has been given)",
+							"type": "string",
+							"maxLength": 30
+						},
+						"emailAddress": {
+							"description": "The candidate's email address, if any",
+							"type": "string",
+							"maxLength": 100
+						},
+						"prn": {
+							"description": "The candidate's ADI PRN (potential register number), if an ADI test",
+							"type": "integer"
+						},
+						"previousADITests": {
+							"description": "The number of previous test attempts, if an ADI test",
+							"type": "integer"
+						},
+						"ethnicityCode": {
+							"description": "A character between A and G representing different categories of ethnicity",
+							"type": "string",
+							"minLength": 1,
+							"maxLength": 1
+						}
+					},
+					"additionalProperties": false
+				},
+				"applicationReference": {
+					"description": "The full application identifier, including applicationId, bookingSequence and checkDigit",
+					"type": "object",
+					"properties": {
+						"applicationId": {
+							"description": "Unique identifier for each test application",
+							"type": "integer"
+						},
+						"bookingSequence": {
+							"description": "Booking sequence number of the test application",
+							"type": "integer"
+						},
+						"checkDigit": {
+							"description": "Reference checksum for the test application",
+							"type": "integer"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"applicationId",
+						"bookingSequence",
+						"checkDigit"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"examiner",
+				"testCentre",
+				"testSlotAttributes",
+				"candidate",
+				"applicationReference"
+			]
+		},
+		"activityCode": {
+			"description": "Code representing the result of the test",
+			"type": "string",
+			"enum": [
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"11",
+				"20",
+				"21",
+				"22",
+				"23",
+				"24",
+				"25",
+				"26",
+				"27",
+				"28",
+				"32",
+				"33",
+				"34",
+				"35",
+				"36",
+				"37",
+				"38",
+				"40",
+				"41",
+				"51",
+				"52",
+				"55",
+				"58",
+				"59",
+				"60",
+				"61",
+				"62",
+				"63",
+				"64",
+				"66",
+				"67",
+				"68",
+				"69",
+				"70",
+				"71",
+				"73",
+				"74",
+				"75",
+				"82",
+				"83"
+			]
+		},
+		"communicationPreferences": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"updatedEmail": {
+					"description": "The email address that the candidate agrees their results can be sent to",
+					"type": "string",
+					"maxLength": 100
+				},
+				"communicationMethod": {
+					"description": "The method of communication by which the candidate agrees to receive their results",
+					"type": "string",
+					"enum": [
+						"Email",
+						"Post",
+						"Support Centre",
+						"Not provided"
+					]
+				},
+				"conductedLanguage": {
+					"description": "The language in which a candidate agrees to perform a test",
+					"type": "string",
+					"enum": [
+						"English",
+						"Cymraeg",
+						"Not provided"
+					]
+				}
+			},
+			"required": [
+				"updatedEmail",
+				"communicationMethod",
+				"conductedLanguage"
+			]
+		},
+		"preTestDeclarations": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"insuranceDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their test vehicle has a valid insurance policy",
+					"type": "boolean"
+				},
+				"residencyDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that they have lived in the UK for a period acceptable for taking the test",
+					"type": "boolean"
+				},
+				"preTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				},
+				"DL196CBTCertNumber": {
+					"description": "The number of the DL196 CBT certificate presented by the candidate",
+					"type": "string"
+				}
+			},
+			"required": [
+				"insuranceDeclarationAccepted",
+				"residencyDeclarationAccepted",
+				"preTestSignature",
+				"mod1CertificateNumber"
+			]
+		},
+		"accompaniment": {
+			"description": "Indicators for anybody else overseeing the test",
+			"type": "object",
+			"properties": {
+				"ADI": {
+					"description": "Indicates whether the ADI was present during the test",
+					"type": "boolean"
+				},
+				"supervisor": {
+					"description": "Indicates whether a DVSA supervisor was present during the test",
+					"type": "boolean"
+				},
+				"interpreter": {
+					"description": "Indicates whether an interpreter was present during the test",
+					"type": "boolean"
+				},
+				"other": {
+					"description": "Indicates whether another individual was present during the test",
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"postTestDeclarations": {
+			"type": "object",
+			"properties": {
+				"healthDeclarationAccepted": {
+					"description": "Whether or not the candidate has declared that their health status hasn't changed since their last application",
+					"type": "boolean"
+				},
+				"passCertificateNumberReceived": {
+					"description": "Indicates whether the candidate acknowledges receipt of the PCN",
+					"type": "boolean"
+				},
+				"postTestSignature": {
+					"description": "Base 64 encoded binary data representing a PNG image of the candidates signature",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"testSummary": {
+			"description": "Recording of other characteristics of the test",
+			"type": "object",
+			"properties": {
+				"routeNumber": {
+					"description": "Number of the route that was taken during the test",
+					"type": "integer",
+					"const": 88
+				},
+				"independentDriving": {
+					"description": "Method chosen to conduct the independent driving section of the test",
+					"type": "string",
+					"enum": [
+						"Sat nav",
+						"Diagram",
+						"Traffic signs",
+						"N/A"
+					]
+				},
+				"candidateDescription": {
+					"description": "Physical description of the candidate",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"debriefWitnessed": {
+					"description": "Indicates whether anybody else (e.g. ADI) was present for the debrief",
+					"type": "boolean"
+				},
+				"identification": {
+					"description": "Indicates which form of ID was provided by the candidate",
+					"type": "string",
+					"enum": [
+						"Licence",
+						"Passport"
+					]
+				},
+				"weatherConditions": {
+					"description": "Description of the type of weather encountered during the test",
+					"type": "array",
+					"items": {
+						"description": "Predefined values for the type of weather encountered during the test",
+						"type": "string",
+						"enum": [
+							"Bright / dry roads",
+							"Bright / wet roads",
+							"Raining through test",
+							"Showers",
+							"Foggy / misty",
+							"Dull / wet roads",
+							"Dull / dry roads",
+							"Snowing",
+							"Icy",
+							"Windy"
+						]
+					}
+				},
+				"D255": {
+					"description": "Indicates whether a D255 form needs to be completed",
+					"type": "boolean"
+				},
+				"additionalInformation": {
+					"description": "Any comments that the DE wants to record about the test",
+					"type": "string"
+				},
+				"circuit": {
+					"description": "Circuit completed (left or right)",
+					"type": "string",
+					"enum": [
+						"Left",
+						"Right"
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"rekeyReason": {
+			"description": "Recording of the rekey reason",
+			"type": "object",
+			"properties": {
+				"transfer": {
+					"description": "Recording of if a rekey was due to a transfer",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"ipadIssue": {
+					"description": "Recording of if a rekey was due to a iPad issue",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"technicalFault": {
+							"description": "If the iPad was not used due to a technical fault",
+							"type": "boolean"
+						},
+						"lost": {
+							"description": "If the iPad was not used as it has been lost",
+							"type": "boolean"
+						},
+						"stolen": {
+							"description": "If the iPad was not used as it has been stolen",
+							"type": "boolean"
+						},
+						"broken": {
+							"description": "If the iPad was not used as it is broken",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"other": {
+					"description": "Recording of if a rekey was due to a different reason",
+					"type": "object",
+					"properties": {
+						"selected": {
+							"description": "If this option was selected",
+							"type": "boolean"
+						},
+						"reason": {
+							"description": "The reason this option was selected",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"rekey": {
+			"description": "Whether the test was rekeyed or not",
+			"type": "boolean"
+		},
+		"rekeyDate": {
+			"description": "Date the test was rekeyed",
+			"type": "string"
+		},
+		"changeMarker": {
+			"description": "Whether the test was conducted by another examiner",
+			"type": "boolean"
+		},
+		"examinerBooked": {
+			"description": "The examiner who the test was booked to",
+			"type": "number"
+		},
+		"examinerConducted": {
+			"description": "The examiner who conducted the test",
+			"type": "number"
+		},
+		"examinerKeyed": {
+			"description": "The examiner who keyed the test into the iPad",
+			"type": "number"
+		},
+		"passCompletion": {
+			"description": "Finalisation of a successful test outcome",
+			"type": "object",
+			"properties": {
+				"provisionalLicenceProvided": {
+					"description": "Indicates whether the candidate submitted their provisional driving licence",
+					"type": "boolean"
+				},
+				"passCertificateNumber": {
+					"description": "The PCN issued to the candidate",
+					"type": "string",
+					"maxLength": 8,
+					"minLength": 8
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"provisionalLicenceProvided",
+				"passCertificateNumber"
+			]
+		},
+		"vehicleDetails": {
+			"additionalProperties": false,
+			"type": "object",
+			"properties": {
+				"schoolBike": {
+					"description": "Indicates whether the bike belongs to a driving school",
+					"type": "boolean"
+				},
+				"gearboxCategory": {
+					"description": "The type of gearbox",
+					"type": "string",
+					"enum": [
+						"Manual",
+						"Automatic"
+					]
+				},
+				"registrationNumber": {
+					"description": "The vehicle registration number",
+					"type": "string",
+					"maxLength": 7
+				}
+			}
+		},
+		"testData": {
+			"description": "Data associated with the test",
+			"type": "object",
+			"properties": {
+				"ETA": {
+					"description": "Indicates whether the examiner had to take verbal action during the test",
+					"type": "object",
+					"properties": {
+						"verbal": {
+							"description": "Indicates that the examiner had to take verbal action",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"drivingFaults": {
+					"description": "The driving faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "The count of the number of driving faults recorded against a test element",
+							"type": "integer"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"seriousFaults": {
+					"description": "The serious faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "Indicator for a serious fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"dangerousFaults": {
+					"description": "The dangerous faults accumulated during the test",
+					"type": "object",
+					"properties": {
+						"controlsThrottle": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsThrottleComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsClutch": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsClutchComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsGears": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsGearsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsFrontbrake": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsFrontbrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsRearBrake": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsRearBrakeComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlsSteering": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"controlsSteeringComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"ancillaryControls": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"ancillaryControlsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffSafety": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffSafetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"moveOffControl": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"moveOffControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsSignalling": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsSignallingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeDirection": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeDirectionComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfMirrorsChangeSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfMirrorsChangeSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsNecessary": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsNecessaryComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsCorrectly": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsCorrectlyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"signalsTimed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"signalsTimedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsApproachSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsApproachSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsObservation": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsObservationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningRight": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningRightComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsTurningLeft": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsTurningLeftComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"junctionsCuttingCorners": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"junctionsCuttingCornersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementOvertaking": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementOvertakingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementMeeting": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementMeetingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"judgementCrossing": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"judgementCrossingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningNormalDriving": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningNormalDrivingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positioningLaneDiscipline": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positioningLaneDisciplineComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"clearanceOrObstructions": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"clearanceOrObstructionsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"followingDistance": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"followingDistanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"useOfSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"useOfSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressAppropriateSpeed": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressAppropriateSpeedComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"progressUndueHesitation": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"progressUndueHesitationComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficSigns": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficSignsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsRoadMarkings": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsRoadMarkingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficLights": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficLightsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsTrafficControllers": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsTrafficControllersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"responseToSignsOtherRoadUsers": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"responseToSignsOtherRoadUsersComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"pedestrianCrossings": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"pedestrianCrossingsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"positionNormalStops": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"positionNormalStopsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"awarenessPlanning": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"awarenessPlanningComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"bends": {
+							"description": "Indicator for a dangerous fault being recorded against a test element",
+							"type": "boolean"
+						},
+						"bendsComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				},
+				"safetyAndBalanceQuestions": {
+					"additionalProperties": false,
+					"description": "Details of the safety and balance questions asked during the test",
+					"properties": {
+						"safetyQuestions": {
+							"items": {
+								"description": "Result of a vehicle checks question",
+								"type": "object",
+								"additionalProperties": false,
+								"properties": {
+									"code": {
+										"description": "Code representing the question that was asked",
+										"type": "string"
+									},
+									"description": {
+										"description": "Description of the question that was asked",
+										"type": "string"
+									},
+									"outcome": {
+										"description": "Outcome of the question that was asked",
+										"type": "string",
+										"enum": [
+											"P",
+											"DF",
+											"S",
+											"D"
+										]
+									}
+								}
+							},
+							"type": "array"
+						},
+						"safetyComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"balanceQuestions": {
+							"items": {
+								"description": "Result of a vehicle checks question",
+								"type": "object",
+								"additionalProperties": false,
+								"properties": {
+									"code": {
+										"description": "Code representing the question that was asked",
+										"type": "string"
+									},
+									"description": {
+										"description": "Description of the question that was asked",
+										"type": "string"
+									},
+									"outcome": {
+										"description": "Outcome of the question that was asked",
+										"type": "string",
+										"enum": [
+											"P",
+											"DF",
+											"S",
+											"D"
+										]
+									}
+								}
+							},
+							"type": "array"
+						},
+						"balanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"type": "object"
+				},
+				"eco": {
+					"description": "Assessment of the eco friendly manner of driving",
+					"type": "object",
+					"properties": {
+						"completed": {
+							"description": "Indicates that the eco friendly manner of driving has been assessed",
+							"type": "boolean"
+						},
+						"adviceGivenControl": {
+							"description": "Indicates that advice was given on the Control aspect of eco driving",
+							"type": "boolean"
+						},
+						"adviceGivenPlanning": {
+							"description": "Indicates that advice was given on the Planning aspect of eco driving",
+							"type": "boolean"
+						}
+					},
+					"additionalProperties": false
+				},
+				"eyesightTest": {
+					"type": "object",
+					"properties": {
+						"complete": {
+							"type": "boolean"
+						},
+						"seriousFault": {
+							"description": "Whether the candidate has failed the eyesight test",
+							"type": "boolean"
+						},
+						"faultComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"version",
+		"category",
+		"journalData",
+		"activityCode",
+		"rekey",
+		"changeMarker",
+		"examinerBooked",
+		"examinerConducted",
+		"examinerKeyed"
+	]
 }

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -88,6 +88,12 @@
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "cli-color": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
@@ -102,6 +108,12 @@
         "timers-ext": "^0.1.5"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "complexion": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/complexion/-/complexion-0.2.0.tgz",
@@ -114,6 +126,12 @@
       "integrity": "sha512-aZd8ke/Y5U9WtvPEN1kRbwfsc/tjTGS1RsJK9IVhealo5qecjkUjLIEzcQhIGoceIA0LQP+o7fMpVeHyj6PaXg==",
       "dev": true
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -122,6 +140,12 @@
       "requires": {
         "es5-ext": "^0.10.9"
       }
+    },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc=",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.1.1",
@@ -201,11 +225,50 @@
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -215,6 +278,30 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-deref-sync": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
+      "integrity": "sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "json-schema-ref-parser": {
@@ -278,6 +365,17 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "memoizee": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
@@ -293,6 +391,12 @@
         "next-tick": "1",
         "timers-ext": "^0.1.5"
       }
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo=",
+      "dev": true
     },
     "minimist": {
       "version": "1.2.0",
@@ -418,6 +522,12 @@
         "next-tick": "1"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "ts-node": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
@@ -435,6 +545,12 @@
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
       "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "dev": true
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
     },
     "yn": {

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/dvsa/mes-api-definitions#readme",
   "devDependencies": {
     "deepmerge": "^4.1.1",
+    "json-schema-deref-sync": "^0.13.0",
     "json-schema-to-typescript": "^6.1.3",
     "pretty-js": "^0.2.0",
     "ts-node": "^8.4.1",


### PR DESCRIPTION
# Description and relevant Jira numbers
- Adds new function to de-reference json schema files
- Resolves issue for Mod 1 and 2 where schemas containing references to external files cause errors when passing to enjoi for validation. 
- **Note:** The categories/AM1.index.json and categories/AM1.index.json have been fully regenerated as standalone schemas (dereferenced from the common schema) as a result of this change, hence the 6k or so lines added

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA