### PR TITLE
MES-4810 updated single fault competencies

### DIFF
--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -191,19 +191,19 @@ export type SchoolBike = boolean;
  */
 export type SingleFaultCompetencyOutcome = "DF" | "S" | "D";
 /**
- * The count of the number of driving faults recorded against a test element
- *
- * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
- * via the `definition` "drivingFaultCount".
- */
-export type DrivingFaultCount = number;
-/**
  * Comments recorded against a fault
  *
  * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
  * via the `definition` "faultComments".
  */
 export type FaultComments = string;
+/**
+ * The count of the number of driving faults recorded against a test element
+ *
+ * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
+ * via the `definition` "drivingFaultCount".
+ */
+export type DrivingFaultCount = number;
 /**
  * Indicator for a serious fault being recorded against a test element
  *
@@ -716,18 +716,33 @@ export interface VehicleDetails {
  * via the `definition` "testData".
  */
 export interface TestData {
-  useOfStand?: SingleFaultCompetencyOutcome;
-  manualHandling?: SingleFaultCompetencyOutcome;
-  slalom?: SingleFaultCompetencyOutcome;
-  slowControl?: SingleFaultCompetencyOutcome;
-  uTurn?: SingleFaultCompetencyOutcome;
-  controlledStop?: SingleFaultCompetencyOutcome;
+  singleFaultCompetencies?: SingleFaultCompetencies;
   emergencyStop?: EmergencyStop;
   avoidance?: Avoidance;
   drivingFaults?: DrivingFaults;
   seriousFaults?: SeriousFaults;
   dangerousFaults?: DangerousFaults;
   ETA?: ETA;
+}
+/**
+ * the single fault competencies associated with the test
+ *
+ * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
+ * via the `definition` "singleFaultCompetencies".
+ */
+export interface SingleFaultCompetencies {
+  useOfStand?: SingleFaultCompetencyOutcome;
+  useOfStandComments?: FaultComments;
+  manualHandling?: SingleFaultCompetencyOutcome;
+  manualHandlingComments?: FaultComments;
+  slalom?: SingleFaultCompetencyOutcome;
+  slalomComments?: FaultComments;
+  slowControl?: SingleFaultCompetencyOutcome;
+  slowControlComments?: FaultComments;
+  uTurn?: SingleFaultCompetencyOutcome;
+  uTurnComments?: FaultComments;
+  controlledStop?: SingleFaultCompetencyOutcome;
+  controlledStopComments?: FaultComments;
 }
 /**
  * The outcome of emergency stop tests

--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -725,7 +725,7 @@ export interface TestData {
   ETA?: ETA;
 }
 /**
- * the single fault competencies associated with the test
+ * Single fault competencies associated with the test
  *
  * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
  * via the `definition` "singleFaultCompetencies".
@@ -764,6 +764,7 @@ export interface EmergencyStop {
    */
   speedNotMetSeriousFault?: boolean;
   outcome?: SingleFaultCompetencyOutcome;
+  comments?: FaultComments;
 }
 /**
  * The outcome of avoidance tests
@@ -785,6 +786,7 @@ export interface Avoidance {
    */
   speedNotMetSeriousFault?: boolean;
   outcome?: SingleFaultCompetencyOutcome;
+  comments?: FaultComments;
 }
 /**
  * The driving faults accumulated during the test

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -4,7 +4,7 @@
 	"definitions": {
 		"singleFaultCompetencies": {
 			"additionalProperties": false,
-			"description": "the single fault competencies associated with the test",
+			"description": "Single fault competencies associated with the test",
 			"properties": {
 				"useOfStand": {
 					"description": "The possible outcomes of any single fault competency",
@@ -106,7 +106,7 @@
 			"properties": {
 				"singleFaultCompetencies": {
 					"additionalProperties": false,
-					"description": "the single fault competencies associated with the test",
+					"description": "Single fault competencies associated with the test",
 					"properties": {
 						"useOfStand": {
 							"description": "The possible outcomes of any single fault competency",
@@ -2444,7 +2444,7 @@
 			"properties": {
 				"singleFaultCompetencies": {
 					"additionalProperties": false,
-					"description": "the single fault competencies associated with the test",
+					"description": "Single fault competencies associated with the test",
 					"properties": {
 						"useOfStand": {
 							"description": "The possible outcomes of any single fault competency",

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -219,6 +219,11 @@
 								"D"
 							],
 							"type": "string"
+						},
+						"comments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},
@@ -247,6 +252,11 @@
 								"D"
 							],
 							"type": "string"
+						},
+						"comments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},
@@ -1667,6 +1677,11 @@
 						"D"
 					],
 					"type": "string"
+				},
+				"comments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
 				}
 			}
 		},
@@ -1695,6 +1710,11 @@
 						"D"
 					],
 					"type": "string"
+				},
+				"comments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
 				}
 			}
 		},
@@ -2537,6 +2557,11 @@
 								"D"
 							],
 							"type": "string"
+						},
+						"comments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},
@@ -2565,6 +2590,11 @@
 								"D"
 							],
 							"type": "string"
+						},
+						"comments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -2,6 +2,96 @@
 	"title": "Test Result Cat AM1 Schema",
 	"type": "object",
 	"definitions": {
+		"singleFaultCompetencies": {
+			"additionalProperties": false,
+			"description": "the single fault competencies associated with the test",
+			"properties": {
+				"useOfStand": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"useOfStandComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"manualHandling": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"manualHandlingComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"slalom": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slalomComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"slowControl": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"slowControlComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"uTurn": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"uTurnComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"controlledStop": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"controlledStopComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				}
+			}
+		},
 		"circuit": {
 			"description": "Circuit completed (left or right)",
 			"type": "string",
@@ -14,59 +104,95 @@
 			"additionalProperties": false,
 			"description": "Data associated with the test",
 			"properties": {
-				"useOfStand": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"manualHandling": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"slalom": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"slowControl": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"uTurn": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"controlledStop": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
+				"singleFaultCompetencies": {
+					"additionalProperties": false,
+					"description": "the single fault competencies associated with the test",
+					"properties": {
+						"useOfStand": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"useOfStandComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"manualHandling": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"manualHandlingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"slalom": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"slalomComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"slowControl": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"slowControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"uTurn": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"uTurnComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlledStop": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"controlledStopComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					}
 				},
 				"emergencyStop": {
 					"description": "The outcome of emergency stop tests",
@@ -2296,59 +2422,95 @@
 			"additionalProperties": false,
 			"description": "Data associated with the test",
 			"properties": {
-				"useOfStand": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"manualHandling": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"slalom": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"slowControl": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"uTurn": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
-				},
-				"controlledStop": {
-					"description": "The possible outcomes of any single fault competency",
-					"enum": [
-						"DF",
-						"S",
-						"D"
-					],
-					"type": "string"
+				"singleFaultCompetencies": {
+					"additionalProperties": false,
+					"description": "the single fault competencies associated with the test",
+					"properties": {
+						"useOfStand": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"useOfStandComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"manualHandling": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"manualHandlingComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"slalom": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"slalomComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"slowControl": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"slowControlComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"uTurn": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"uTurnComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"controlledStop": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"controlledStopComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						}
+					}
 				},
 				"emergencyStop": {
 					"description": "The outcome of emergency stop tests",

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -2,6 +2,48 @@
   "title": "Test Result Cat AM1 Schema",
   "type": "object",
   "definitions": {
+    "singleFaultCompetencies": {
+      "additionalProperties": false,
+      "description": "the single fault competencies associated with the test",
+      "properties": {
+        "useOfStand": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "useOfStandComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "manualHandling": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "manualHandlingComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "slalom": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "slalomComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "slowControl": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "slowControlComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "uTurn": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "uTurnComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "controlledStop": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "controlledStopComments": {
+          "$ref": "#/definitions/faultComments"
+        }
+      }
+    },
     "circuit": {
       "description": "Circuit completed (left or right)",
       "type": "string",
@@ -14,23 +56,8 @@
       "additionalProperties": false,
       "description": "Data associated with the test",
       "properties": {
-        "useOfStand": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "manualHandling": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "slalom": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "slowControl": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "uTurn": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
-        },
-        "controlledStop": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        "singleFaultCompetencies": {
+          "$ref": "#/definitions/singleFaultCompetencies"
         },
         "emergencyStop": {
           "$ref": "#/definitions/emergencyStop"

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -4,7 +4,7 @@
   "definitions": {
     "singleFaultCompetencies": {
       "additionalProperties": false,
-      "description": "the single fault competencies associated with the test",
+      "description": "Single fault competencies associated with the test",
       "properties": {
         "useOfStand": {
           "$ref": "#/definitions/singleFaultCompetencyOutcome"

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -380,6 +380,9 @@
         },
         "outcome": {
           "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "comments": {
+          "$ref": "#/definitions/faultComments"
         }
       }
     },
@@ -402,6 +405,9 @@
         },
         "outcome": {
           "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "comments": {
+          "$ref": "#/definitions/faultComments"
         }
       }
     },

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
- Updates mod 1 to add single fault competencies and comments
- Adds comments field to existing emergencyStop and avoidance competencies

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA