### PR TITLE
MES-4800 - Removes provisionalLicenceProvided from mod 1

### DIFF
--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -687,10 +687,6 @@ export interface Other {
  */
 export interface PassCompletion {
   /**
-   * Indicates whether the candidate submitted their provisional driving licence
-   */
-  provisionalLicenceProvided: boolean;
-  /**
    * The PCN issued to the candidate
    */
   passCertificateNumber: string;

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -1631,10 +1631,6 @@
 			"description": "Finalisation of a successful test outcome",
 			"type": "object",
 			"properties": {
-				"provisionalLicenceProvided": {
-					"description": "Indicates whether the candidate submitted their provisional driving licence",
-					"type": "boolean"
-				},
 				"passCertificateNumber": {
 					"description": "The PCN issued to the candidate",
 					"type": "string",
@@ -1644,7 +1640,6 @@
 			},
 			"additionalProperties": false,
 			"required": [
-				"provisionalLicenceProvided",
 				"passCertificateNumber"
 			]
 		},
@@ -2397,10 +2392,6 @@
 			"description": "Finalisation of a successful test outcome",
 			"type": "object",
 			"properties": {
-				"provisionalLicenceProvided": {
-					"description": "Indicates whether the candidate submitted their provisional driving licence",
-					"type": "boolean"
-				},
 				"passCertificateNumber": {
 					"description": "The PCN issued to the candidate",
 					"type": "string",
@@ -2410,7 +2401,6 @@
 			},
 			"additionalProperties": false,
 			"required": [
-				"provisionalLicenceProvided",
 				"passCertificateNumber"
 			]
 		},

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -340,10 +340,6 @@
       "description": "Finalisation of a successful test outcome",
       "type": "object",
       "properties": {
-        "provisionalLicenceProvided": {
-          "description": "Indicates whether the candidate submitted their provisional driving licence",
-          "type": "boolean"
-        },
         "passCertificateNumber": {
           "description": "The PCN issued to the candidate",
           "type": "string",
@@ -353,7 +349,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "provisionalLicenceProvided",
         "passCertificateNumber"
       ]
     },

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
- `provisionalLicenceProvided` is not relevant to A Mod 1 tests so it has been removed.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA