### PR TITLE
New speed requirement types MES-4963

### DIFF
--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -198,6 +198,13 @@ export type SingleFaultCompetencyOutcome = "DF" | "S" | "D";
  */
 export type FaultComments = string;
 /**
+ * The possible outcomes of speed requirment fault competency
+ *
+ * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
+ * via the `definition` "SpeedRequirementCompetencyOutcome".
+ */
+export type SpeedRequirementCompetencyOutcome = "S";
+/**
  * The count of the number of driving faults recorded against a test element
  *
  * This interface was referenced by `TestResultCatAM1Schema`'s JSON-Schema
@@ -739,6 +746,10 @@ export interface SingleFaultCompetencies {
   uTurnComments?: FaultComments;
   controlledStop?: SingleFaultCompetencyOutcome;
   controlledStopComments?: FaultComments;
+  emergencyStop?: SingleFaultCompetencyOutcome;
+  emergancyStopComments?: FaultComments;
+  avoidance?: SingleFaultCompetencyOutcome;
+  avoidanceComments?: FaultComments;
 }
 /**
  * The outcome of emergency stop tests
@@ -755,11 +766,7 @@ export interface EmergencyStop {
    * The speed of the second attempt
    */
   secondAttempt?: number;
-  /**
-   * Whether the required speed was not met
-   */
-  speedNotMetSeriousFault?: boolean;
-  outcome?: SingleFaultCompetencyOutcome;
+  outcome?: SpeedRequirementCompetencyOutcome;
   comments?: FaultComments;
 }
 /**
@@ -777,11 +784,7 @@ export interface Avoidance {
    * The speed of the second attempt
    */
   secondAttempt?: number;
-  /**
-   * Whether the required speed was not met
-   */
-  speedNotMetSeriousFault?: boolean;
-  outcome?: SingleFaultCompetencyOutcome;
+  outcome?: SpeedRequirementCompetencyOutcome;
   comments?: FaultComments;
 }
 /**

--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -747,7 +747,7 @@ export interface SingleFaultCompetencies {
   controlledStop?: SingleFaultCompetencyOutcome;
   controlledStopComments?: FaultComments;
   emergencyStop?: SingleFaultCompetencyOutcome;
-  emergancyStopComments?: FaultComments;
+  emergencyStopComments?: FaultComments;
   avoidance?: SingleFaultCompetencyOutcome;
   avoidanceComments?: FaultComments;
 }

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -89,6 +89,34 @@
 					"description": "Comments recorded against a fault",
 					"type": "string",
 					"maxLength": 1000
+				},
+				"emergencyStop": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"emergancyStopComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
+				},
+				"avoidance": {
+					"description": "The possible outcomes of any single fault competency",
+					"enum": [
+						"DF",
+						"S",
+						"D"
+					],
+					"type": "string"
+				},
+				"avoidanceComments": {
+					"description": "Comments recorded against a fault",
+					"type": "string",
+					"maxLength": 1000
 				}
 			}
 		},
@@ -191,6 +219,34 @@
 							"description": "Comments recorded against a fault",
 							"type": "string",
 							"maxLength": 1000
+						},
+						"emergencyStop": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"emergancyStopComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"avoidance": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"avoidanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},
@@ -207,16 +263,10 @@
 							"description": "The speed of the second attempt",
 							"type": "integer"
 						},
-						"speedNotMetSeriousFault": {
-							"description": "Whether the required speed was not met",
-							"type": "boolean"
-						},
 						"outcome": {
-							"description": "The possible outcomes of any single fault competency",
+							"description": "The possible outcomes of speed requirment fault competency",
 							"enum": [
-								"DF",
-								"S",
-								"D"
+								"S"
 							],
 							"type": "string"
 						},
@@ -240,16 +290,10 @@
 							"description": "The speed of the second attempt",
 							"type": "integer"
 						},
-						"speedNotMetSeriousFault": {
-							"description": "Whether the required speed was not met",
-							"type": "boolean"
-						},
 						"outcome": {
-							"description": "The possible outcomes of any single fault competency",
+							"description": "The possible outcomes of speed requirment fault competency",
 							"enum": [
-								"DF",
-								"S",
-								"D"
+								"S"
 							],
 							"type": "string"
 						},
@@ -386,6 +430,13 @@
 				"DF",
 				"S",
 				"D"
+			],
+			"type": "string"
+		},
+		"SpeedRequirementCompetencyOutcome": {
+			"description": "The possible outcomes of speed requirment fault competency",
+			"enum": [
+				"S"
 			],
 			"type": "string"
 		},
@@ -1660,16 +1711,10 @@
 					"description": "The speed of the second attempt",
 					"type": "integer"
 				},
-				"speedNotMetSeriousFault": {
-					"description": "Whether the required speed was not met",
-					"type": "boolean"
-				},
 				"outcome": {
-					"description": "The possible outcomes of any single fault competency",
+					"description": "The possible outcomes of speed requirment fault competency",
 					"enum": [
-						"DF",
-						"S",
-						"D"
+						"S"
 					],
 					"type": "string"
 				},
@@ -1693,16 +1738,10 @@
 					"description": "The speed of the second attempt",
 					"type": "integer"
 				},
-				"speedNotMetSeriousFault": {
-					"description": "Whether the required speed was not met",
-					"type": "boolean"
-				},
 				"outcome": {
-					"description": "The possible outcomes of any single fault competency",
+					"description": "The possible outcomes of speed requirment fault competency",
 					"enum": [
-						"DF",
-						"S",
-						"D"
+						"S"
 					],
 					"type": "string"
 				},
@@ -2519,6 +2558,34 @@
 							"description": "Comments recorded against a fault",
 							"type": "string",
 							"maxLength": 1000
+						},
+						"emergencyStop": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"emergancyStopComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
+						},
+						"avoidance": {
+							"description": "The possible outcomes of any single fault competency",
+							"enum": [
+								"DF",
+								"S",
+								"D"
+							],
+							"type": "string"
+						},
+						"avoidanceComments": {
+							"description": "Comments recorded against a fault",
+							"type": "string",
+							"maxLength": 1000
 						}
 					}
 				},
@@ -2535,16 +2602,10 @@
 							"description": "The speed of the second attempt",
 							"type": "integer"
 						},
-						"speedNotMetSeriousFault": {
-							"description": "Whether the required speed was not met",
-							"type": "boolean"
-						},
 						"outcome": {
-							"description": "The possible outcomes of any single fault competency",
+							"description": "The possible outcomes of speed requirment fault competency",
 							"enum": [
-								"DF",
-								"S",
-								"D"
+								"S"
 							],
 							"type": "string"
 						},
@@ -2568,16 +2629,10 @@
 							"description": "The speed of the second attempt",
 							"type": "integer"
 						},
-						"speedNotMetSeriousFault": {
-							"description": "Whether the required speed was not met",
-							"type": "boolean"
-						},
 						"outcome": {
-							"description": "The possible outcomes of any single fault competency",
+							"description": "The possible outcomes of speed requirment fault competency",
 							"enum": [
-								"DF",
-								"S",
-								"D"
+								"S"
 							],
 							"type": "string"
 						},

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -99,7 +99,7 @@
 					],
 					"type": "string"
 				},
-				"emergancyStopComments": {
+				"emergencyStopComments": {
 					"description": "Comments recorded against a fault",
 					"type": "string",
 					"maxLength": 1000
@@ -229,7 +229,7 @@
 							],
 							"type": "string"
 						},
-						"emergancyStopComments": {
+						"emergencyStopComments": {
 							"description": "Comments recorded against a fault",
 							"type": "string",
 							"maxLength": 1000
@@ -2568,7 +2568,7 @@
 							],
 							"type": "string"
 						},
-						"emergancyStopComments": {
+						"emergencyStopComments": {
 							"description": "Comments recorded against a fault",
 							"type": "string",
 							"maxLength": 1000

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -45,7 +45,7 @@
         "emergencyStop": {
           "$ref": "#/definitions/singleFaultCompetencyOutcome"
         },
-        "emergancyStopComments": {
+        "emergencyStopComments": {
           "$ref": "#/definitions/faultComments"
         },
         "avoidance": {

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -41,6 +41,18 @@
         },
         "controlledStopComments": {
           "$ref": "#/definitions/faultComments"
+        },
+        "emergencyStop": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "emergancyStopComments": {
+          "$ref": "#/definitions/faultComments"
+        },
+        "avoidance": {
+          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+        },
+        "avoidanceComments": {
+          "$ref": "#/definitions/faultComments"
         }
       }
     },
@@ -86,6 +98,13 @@
         "DF",
         "S",
         "D"
+      ],
+      "type": "string"
+    },
+    "SpeedRequirementCompetencyOutcome": {
+      "description": "The possible outcomes of speed requirment fault competency",
+      "enum": [
+        "S"
       ],
       "type": "string"
     },
@@ -369,12 +388,8 @@
           "description": "The speed of the second attempt",
           "type": "integer"
         },
-        "speedNotMetSeriousFault": {
-          "description": "Whether the required speed was not met",
-          "type": "boolean"
-        },
         "outcome": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+          "$ref": "#/definitions/SpeedRequirementCompetencyOutcome"
         },
         "comments": {
           "$ref": "#/definitions/faultComments"
@@ -394,12 +409,8 @@
           "description": "The speed of the second attempt",
           "type": "integer"
         },
-        "speedNotMetSeriousFault": {
-          "description": "Whether the required speed was not met",
-          "type": "boolean"
-        },
         "outcome": {
-          "$ref": "#/definitions/singleFaultCompetencyOutcome"
+          "$ref": "#/definitions/SpeedRequirementCompetencyOutcome"
         },
         "comments": {
           "$ref": "#/definitions/faultComments"

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.19.2",
+  "version": "3.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.19.2",
+  "version": "3.20.0",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers
Changes the speed requirement in CAT A mod 1, by removing the emergency stop and avoidance into single fault types.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name complies with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA