### PR TITLE
Core: test schema version inconsistent with npmjs

### DIFF
--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.20.0",
+  "version": "3.20.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.20.0",
+  "version": "3.20.2",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
The current version is 3.19.2, however, a 3.20.0 and 3.20.1 have been published and deprecated.

Bumps to 3.20.2 which is the newest version number