### PR TITLE
feat(MES-5008): renaming TestSummary property `modeOfTransport` and schema defin…

### DIFF
--- a/mes-test-schema/categories/AM2/index.d.ts
+++ b/mes-test-schema/categories/AM2/index.d.ts
@@ -118,6 +118,13 @@ export type DL196CBTCertNumber = string;
  */
 export type IndependentDriving = "Sat nav" | "Diagram" | "Traffic signs" | "N/A";
 /**
+ * Method of transportation the driving examiner conducted the test on
+ *
+ * This interface was referenced by `TestResultCatAM2Schema`'s JSON-Schema
+ * via the `definition` "modeOfTransport".
+ */
+export type ModeOfTransport = "Bike to bike" | "Car to bike" | "N/A";
+/**
  * Indicates which form of ID was provided by the candidate
  *
  * This interface was referenced by `TestResultCatAM2Schema`'s JSON-Schema
@@ -522,10 +529,7 @@ export interface TestSummary {
    */
   routeNumber?: number;
   independentDriving?: IndependentDriving;
-  /**
-   * Method of transportation the driving examiner conducted the test on
-   */
-  testConductedOn?: "Bike to bike" | "Car to bike" | "N/A";
+  modeOfTransport?: ModeOfTransport;
   /**
    * Physical description of the candidate
    */

--- a/mes-test-schema/categories/AM2/index.json
+++ b/mes-test-schema/categories/AM2/index.json
@@ -38,6 +38,15 @@
 				"N/A"
 			]
 		},
+		"modeOfTransport": {
+			"description": "Method of transportation the driving examiner conducted the test on",
+			"type": "string",
+			"enum": [
+				"Bike to bike",
+				"Car to bike",
+				"N/A"
+			]
+		},
 		"identification": {
 			"description": "Indicates which form of ID was provided by the candidate",
 			"type": "string",
@@ -539,7 +548,7 @@
 						"N/A"
 					]
 				},
-				"testConductedOn": {
+				"modeOfTransport": {
 					"description": "Method of transportation the driving examiner conducted the test on",
 					"type": "string",
 					"enum": [
@@ -3828,7 +3837,7 @@
 						"N/A"
 					]
 				},
-				"testConductedOn": {
+				"modeOfTransport": {
 					"description": "Method of transportation the driving examiner conducted the test on",
 					"type": "string",
 					"enum": [

--- a/mes-test-schema/category-definitions/AM2/index.json
+++ b/mes-test-schema/category-definitions/AM2/index.json
@@ -11,6 +11,15 @@
     "independentDriving": {
       "$ref": "../common/index.json#/definitions/independentDriving"
     },
+    "modeOfTransport": {
+      "description": "Method of transportation the driving examiner conducted the test on",
+      "type": "string",
+      "enum": [
+        "Bike to bike",
+        "Car to bike",
+        "N/A"
+      ]
+    },
     "identification": {
       "$ref": "../common/index.json#/definitions/identification"
     },
@@ -73,14 +82,8 @@
         "independentDriving": {
           "$ref": "#/definitions/independentDriving"
         },
-        "testConductedOn": {
-          "description": "Method of transportation the driving examiner conducted the test on",
-          "type": "string",
-          "enum": [
-            "Bike to bike",
-            "Car to bike",
-            "N/A"
-          ]
+        "modeOfTransport": {
+          "$ref": "#/definitions/modeOfTransport"
         },
         "candidateDescription": {
           "description": "Physical description of the candidate",

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
…ition update

# Description and relevant Jira numbers

Iterating on early development done against - https://jira.dvsacloud.uk/browse/MES-5008
- Renaming `testConductedOn` => `modeOfTransport`.
- Updated schema definition so that ModeOfTransport type is generated in `.d.ts`.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [x] PR link added to JIRA