### PR TITLE
Mes 5733 - Allow alphanumeric delegated examiner ID

### DIFF
--- a/mes-test-schema/categories/ADI2/index.json
+++ b/mes-test-schema/categories/ADI2/index.json
@@ -1822,11 +1822,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/ADI2/index.json
+++ b/mes-test-schema/categories/ADI2/index.json
@@ -1822,17 +1822,11 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": [
-				"number",
-				"string"
-			]
+			"type": "number"
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": [
-				"number",
-				"string"
-			]
+			"type": "number"
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/AM1/index.d.ts
+++ b/mes-test-schema/categories/AM1/index.d.ts
@@ -276,11 +276,11 @@ export interface TestResultCatAM1Schema {
   /**
    * The examiner who the test was booked to
    */
-  examinerBooked: number;
+  examinerBooked: number | string;
   /**
    * The examiner who conducted the test
    */
-  examinerConducted: number;
+  examinerConducted: number | string;
   /**
    * The examiner who keyed the test into the iPad
    */

--- a/mes-test-schema/categories/AM1/index.json
+++ b/mes-test-schema/categories/AM1/index.json
@@ -2431,11 +2431,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/AM2/index.d.ts
+++ b/mes-test-schema/categories/AM2/index.d.ts
@@ -227,11 +227,11 @@ export interface TestResultCatAM2Schema {
   /**
    * The examiner who the test was booked to
    */
-  examinerBooked: number;
+  examinerBooked: number | string;
   /**
    * The examiner who conducted the test
    */
-  examinerConducted: number;
+  examinerConducted: number | string;
   /**
    * The examiner who keyed the test into the iPad
    */

--- a/mes-test-schema/categories/AM2/index.json
+++ b/mes-test-schema/categories/AM2/index.json
@@ -4252,11 +4252,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -1787,11 +1787,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -1807,11 +1807,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/C/index.json
+++ b/mes-test-schema/categories/C/index.json
@@ -1783,11 +1783,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/C1/index.json
+++ b/mes-test-schema/categories/C1/index.json
@@ -1780,11 +1780,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/C1E/index.json
+++ b/mes-test-schema/categories/C1E/index.json
@@ -1798,11 +1798,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/CE/index.json
+++ b/mes-test-schema/categories/CE/index.json
@@ -1801,11 +1801,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/CPC/index.d.ts
+++ b/mes-test-schema/categories/CPC/index.d.ts
@@ -223,11 +223,11 @@ export interface TestResultCatCPCSchema {
   /**
    * The examiner who the test was booked to
    */
-  examinerBooked: number;
+  examinerBooked: number | string;
   /**
    * The examiner who conducted the test
    */
-  examinerConducted: number;
+  examinerConducted: number | string;
   /**
    * The examiner who keyed the test into the iPad
    */

--- a/mes-test-schema/categories/CPC/index.json
+++ b/mes-test-schema/categories/CPC/index.json
@@ -2727,17 +2727,11 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": [
-				"number",
-				"string"
-			]
+			"type": "number"
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": [
-				"number",
-				"string"
-			]
+			"type": "number"
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/CPC/index.json
+++ b/mes-test-schema/categories/CPC/index.json
@@ -2727,11 +2727,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/D/index.json
+++ b/mes-test-schema/categories/D/index.json
@@ -1840,11 +1840,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/D1/index.json
+++ b/mes-test-schema/categories/D1/index.json
@@ -1837,11 +1837,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/D1E/index.json
+++ b/mes-test-schema/categories/D1E/index.json
@@ -1855,11 +1855,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/DE/index.json
+++ b/mes-test-schema/categories/DE/index.json
@@ -1858,11 +1858,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/F/index.json
+++ b/mes-test-schema/categories/F/index.json
@@ -1808,11 +1808,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/G/index.json
+++ b/mes-test-schema/categories/G/index.json
@@ -1808,11 +1808,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/H/index.json
+++ b/mes-test-schema/categories/H/index.json
@@ -1808,11 +1808,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/K/index.json
+++ b/mes-test-schema/categories/K/index.json
@@ -1795,11 +1795,17 @@
 		},
 		"examinerBooked": {
 			"description": "The examiner who the test was booked to",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerConducted": {
 			"description": "The examiner who conducted the test",
-			"type": "number"
+			"type": [
+				"number",
+				"string"
+			]
 		},
 		"examinerKeyed": {
 			"description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/categories/common/index.d.ts
+++ b/mes-test-schema/categories/common/index.d.ts
@@ -294,11 +294,11 @@ export interface TestResultCommonSchema {
   /**
    * The examiner who the test was booked to
    */
-  examinerBooked: number;
+  examinerBooked: number | string;
   /**
    * The examiner who conducted the test
    */
-  examinerConducted: number;
+  examinerConducted: number | string;
   /**
    * The examiner who keyed the test into the iPad
    */

--- a/mes-test-schema/categories/common/index.json
+++ b/mes-test-schema/categories/common/index.json
@@ -1698,11 +1698,11 @@
     },
     "examinerBooked": {
       "description": "The examiner who the test was booked to",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerConducted": {
       "description": "The examiner who conducted the test",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerKeyed": {
       "description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/category-definitions/AM1/index.json
+++ b/mes-test-schema/category-definitions/AM1/index.json
@@ -481,11 +481,11 @@
     },
     "examinerBooked": {
       "description": "The examiner who the test was booked to",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerConducted": {
       "description": "The examiner who conducted the test",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerKeyed": {
       "description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/category-definitions/AM2/index.json
+++ b/mes-test-schema/category-definitions/AM2/index.json
@@ -1170,11 +1170,11 @@
     },
     "examinerBooked": {
       "description": "The examiner who the test was booked to",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerConducted": {
       "description": "The examiner who conducted the test",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerKeyed": {
       "description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/category-definitions/CPC/index.json
+++ b/mes-test-schema/category-definitions/CPC/index.json
@@ -447,11 +447,11 @@
     },
     "examinerBooked": {
       "description": "The examiner who the test was booked to",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerConducted": {
       "description": "The examiner who conducted the test",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerKeyed": {
       "description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/category-definitions/common/index.json
+++ b/mes-test-schema/category-definitions/common/index.json
@@ -1698,11 +1698,11 @@
     },
     "examinerBooked": {
       "description": "The examiner who the test was booked to",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerConducted": {
       "description": "The examiner who conducted the test",
-      "type": "number"
+      "type": ["number", "string"]
     },
     "examinerKeyed": {
       "description": "The examiner who keyed the test into the iPad",

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.26.2",
+  "version": "3.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.26.3",
+  "version": "3.27.0",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers

https://jira.dvsacloud.uk/browse/MES-5733

- Updates `examinerBooked` and `examinerConducted` keys to be number OR string to accommodate delegated examiners' alphanumeric examinerIds.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA