### PR TITLE
Mes-6084: Remove safety questions

### DIFF
--- a/mes-test-schema/categories/ADI2/index.json
+++ b/mes-test-schema/categories/ADI2/index.json
@@ -559,19 +559,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/B/index.json
+++ b/mes-test-schema/categories/B/index.json
@@ -552,19 +552,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/BE/index.json
+++ b/mes-test-schema/categories/BE/index.json
@@ -562,19 +562,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/C/index.json
+++ b/mes-test-schema/categories/C/index.json
@@ -556,19 +556,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/C1/index.json
+++ b/mes-test-schema/categories/C1/index.json
@@ -556,19 +556,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/C1E/index.json
+++ b/mes-test-schema/categories/C1E/index.json
@@ -559,19 +559,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/CE/index.json
+++ b/mes-test-schema/categories/CE/index.json
@@ -559,19 +559,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/CPC/index.json
+++ b/mes-test-schema/categories/CPC/index.json
@@ -1312,6 +1312,7 @@
 			"additionalProperties": false,
 			"required": [
 				"examiner",
+				"testCentre",
 				"testSlotAttributes",
 				"candidate",
 				"applicationReference"

--- a/mes-test-schema/categories/D/index.json
+++ b/mes-test-schema/categories/D/index.json
@@ -44,9 +44,6 @@
 				},
 				"pcvDoorExercise": {
 					"$ref": "#/definitions/pcvDoorExercise"
-				},
-				"safetyQuestions": {
-					"$ref": "#/definitions/safetyQuestions"
 				}
 			},
 			"type": "object"
@@ -554,19 +551,6 @@
 				"code": {
 					"$ref": "#/definitions/questionCode"
 				},
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
 				"description": {
 					"$ref": "#/definitions/questionDescription"
 				},
@@ -1759,22 +1743,6 @@
 				"vehicleChecksCompleted": {
 					"description": "Indicates whether the vehicle checks has been completed",
 					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
-		"safetyQuestions": {
-			"additionalProperties": false,
-			"description": "Details of the safety questions asked during the test",
-			"properties": {
-				"questions": {
-					"items": {
-						"$ref": "#/definitions/safetyQuestionResult"
-					},
-					"type": "array"
-				},
-				"faultComments": {
-					"$ref": "#/definitions/faultComments"
 				}
 			},
 			"type": "object"

--- a/mes-test-schema/categories/D/partial.d.ts
+++ b/mes-test-schema/categories/D/partial.d.ts
@@ -64,7 +64,6 @@ export interface TestData {
   manoeuvres?: Manoeuvres;
   vehicleChecks?: VehicleChecks;
   pcvDoorExercise?: PcvDoorExercise;
-  safetyQuestions?: SafetyQuestions;
 }
 /**
  * The test requirements that must be carried out during a test
@@ -171,32 +170,6 @@ export interface PcvDoorExercise {
   drivingFaultComments?: FaultComments;
   seriousFaultComments?: FaultComments;
   dangerousFaultComments?: FaultComments;
-}
-/**
- * Details of the safety questions asked during the test
- *
- * This interface was referenced by `PartialTestResultCatDSchema`'s JSON-Schema
- * via the `definition` "safetyQuestions".
- */
-export interface SafetyQuestions {
-  questions?: SafetyQuestionResult[];
-  faultComments?: FaultComments;
-}
-/**
- * Result of a safety question
- *
- * This interface was referenced by `PartialTestResultCatDSchema`'s JSON-Schema
- * via the `definition` "safetyQuestionResult".
- */
-export interface SafetyQuestionResult {
-  /**
-   * Description of the question that was asked
-   */
-  description?: string;
-  /**
-   * Outcome of the question that was asked
-   */
-  outcome?: "P" | "DF" | "S" | "D";
 }
 /**
  * This interface was referenced by `PartialTestResultCatDSchema`'s JSON-Schema

--- a/mes-test-schema/categories/D1/index.json
+++ b/mes-test-schema/categories/D1/index.json
@@ -44,9 +44,6 @@
 				},
 				"pcvDoorExercise": {
 					"$ref": "#/definitions/pcvDoorExercise"
-				},
-				"safetyQuestions": {
-					"$ref": "#/definitions/safetyQuestions"
 				}
 			},
 			"type": "object"
@@ -554,19 +551,6 @@
 				"code": {
 					"$ref": "#/definitions/questionCode"
 				},
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
 				"description": {
 					"$ref": "#/definitions/questionDescription"
 				},
@@ -1756,22 +1740,6 @@
 				"vehicleChecksCompleted": {
 					"description": "Indicates whether the vehicle checks has been completed",
 					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
-		"safetyQuestions": {
-			"additionalProperties": false,
-			"description": "Details of the safety questions asked during the test",
-			"properties": {
-				"questions": {
-					"items": {
-						"$ref": "#/definitions/safetyQuestionResult"
-					},
-					"type": "array"
-				},
-				"faultComments": {
-					"$ref": "#/definitions/faultComments"
 				}
 			},
 			"type": "object"

--- a/mes-test-schema/categories/D1/partial.d.ts
+++ b/mes-test-schema/categories/D1/partial.d.ts
@@ -64,7 +64,6 @@ export interface TestData {
   manoeuvres?: Manoeuvres;
   vehicleChecks?: VehicleChecks;
   pcvDoorExercise?: PcvDoorExercise;
-  safetyQuestions?: SafetyQuestions;
 }
 /**
  * The test requirements that must be carried out during a test
@@ -171,32 +170,6 @@ export interface PcvDoorExercise {
   drivingFaultComments?: FaultComments;
   seriousFaultComments?: FaultComments;
   dangerousFaultComments?: FaultComments;
-}
-/**
- * Details of the safety questions asked during the test
- *
- * This interface was referenced by `PartialTestResultCatD1Schema`'s JSON-Schema
- * via the `definition` "safetyQuestions".
- */
-export interface SafetyQuestions {
-  questions?: SafetyQuestionResult[];
-  faultComments?: FaultComments;
-}
-/**
- * Result of a safety question
- *
- * This interface was referenced by `PartialTestResultCatD1Schema`'s JSON-Schema
- * via the `definition` "safetyQuestionResult".
- */
-export interface SafetyQuestionResult {
-  /**
-   * Description of the question that was asked
-   */
-  description?: string;
-  /**
-   * Outcome of the question that was asked
-   */
-  outcome?: "P" | "DF" | "S" | "D";
 }
 /**
  * This interface was referenced by `PartialTestResultCatD1Schema`'s JSON-Schema

--- a/mes-test-schema/categories/D1E/index.json
+++ b/mes-test-schema/categories/D1E/index.json
@@ -45,9 +45,6 @@
 				"pcvDoorExercise": {
 					"$ref": "#/definitions/pcvDoorExercise"
 				},
-				"safetyQuestions": {
-					"$ref": "#/definitions/safetyQuestions"
-				},
 				"uncoupleRecouple": {
 					"$ref": "#/definitions/uncoupleRecouple"
 				}
@@ -557,19 +554,6 @@
 				"code": {
 					"$ref": "#/definitions/questionCode"
 				},
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
 				"description": {
 					"$ref": "#/definitions/questionDescription"
 				},
@@ -1774,22 +1758,6 @@
 				"vehicleChecksCompleted": {
 					"description": "Indicates whether the vehicle checks has been completed",
 					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
-		"safetyQuestions": {
-			"additionalProperties": false,
-			"description": "Details of the safety questions asked during the test",
-			"properties": {
-				"questions": {
-					"items": {
-						"$ref": "#/definitions/safetyQuestionResult"
-					},
-					"type": "array"
-				},
-				"faultComments": {
-					"$ref": "#/definitions/faultComments"
 				}
 			},
 			"type": "object"

--- a/mes-test-schema/categories/D1E/partial.d.ts
+++ b/mes-test-schema/categories/D1E/partial.d.ts
@@ -64,7 +64,6 @@ export interface TestData {
   manoeuvres?: Manoeuvres;
   vehicleChecks?: VehicleChecks;
   pcvDoorExercise?: PcvDoorExercise;
-  safetyQuestions?: SafetyQuestions;
   uncoupleRecouple?: UncoupleRecouple;
 }
 /**
@@ -172,32 +171,6 @@ export interface PcvDoorExercise {
   drivingFaultComments?: FaultComments;
   seriousFaultComments?: FaultComments;
   dangerousFaultComments?: FaultComments;
-}
-/**
- * Details of the safety questions asked during the test
- *
- * This interface was referenced by `PartialTestResultCatD1ESchema`'s JSON-Schema
- * via the `definition` "safetyQuestions".
- */
-export interface SafetyQuestions {
-  questions?: SafetyQuestionResult[];
-  faultComments?: FaultComments;
-}
-/**
- * Result of a safety question
- *
- * This interface was referenced by `PartialTestResultCatD1ESchema`'s JSON-Schema
- * via the `definition` "safetyQuestionResult".
- */
-export interface SafetyQuestionResult {
-  /**
-   * Description of the question that was asked
-   */
-  description?: string;
-  /**
-   * Outcome of the question that was asked
-   */
-  outcome?: "P" | "DF" | "S" | "D";
 }
 /**
  * This interface was referenced by `PartialTestResultCatD1ESchema`'s JSON-Schema

--- a/mes-test-schema/categories/DE/index.json
+++ b/mes-test-schema/categories/DE/index.json
@@ -45,9 +45,6 @@
 				"pcvDoorExercise": {
 					"$ref": "#/definitions/pcvDoorExercise"
 				},
-				"safetyQuestions": {
-					"$ref": "#/definitions/safetyQuestions"
-				},
 				"uncoupleRecouple": {
 					"$ref": "#/definitions/uncoupleRecouple"
 				}
@@ -557,19 +554,6 @@
 				"code": {
 					"$ref": "#/definitions/questionCode"
 				},
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
 				"description": {
 					"$ref": "#/definitions/questionDescription"
 				},
@@ -1777,22 +1761,6 @@
 				"vehicleChecksCompleted": {
 					"description": "Indicates whether the vehicle checks has been completed",
 					"type": "boolean"
-				}
-			},
-			"type": "object"
-		},
-		"safetyQuestions": {
-			"additionalProperties": false,
-			"description": "Details of the safety questions asked during the test",
-			"properties": {
-				"questions": {
-					"items": {
-						"$ref": "#/definitions/safetyQuestionResult"
-					},
-					"type": "array"
-				},
-				"faultComments": {
-					"$ref": "#/definitions/faultComments"
 				}
 			},
 			"type": "object"

--- a/mes-test-schema/categories/DE/partial.d.ts
+++ b/mes-test-schema/categories/DE/partial.d.ts
@@ -64,7 +64,6 @@ export interface TestData {
   manoeuvres?: Manoeuvres;
   vehicleChecks?: VehicleChecks;
   pcvDoorExercise?: PcvDoorExercise;
-  safetyQuestions?: SafetyQuestions;
   uncoupleRecouple?: UncoupleRecouple;
 }
 /**
@@ -172,32 +171,6 @@ export interface PcvDoorExercise {
   drivingFaultComments?: FaultComments;
   seriousFaultComments?: FaultComments;
   dangerousFaultComments?: FaultComments;
-}
-/**
- * Details of the safety questions asked during the test
- *
- * This interface was referenced by `PartialTestResultCatDESchema`'s JSON-Schema
- * via the `definition` "safetyQuestions".
- */
-export interface SafetyQuestions {
-  questions?: SafetyQuestionResult[];
-  faultComments?: FaultComments;
-}
-/**
- * Result of a safety question
- *
- * This interface was referenced by `PartialTestResultCatDESchema`'s JSON-Schema
- * via the `definition` "safetyQuestionResult".
- */
-export interface SafetyQuestionResult {
-  /**
-   * Description of the question that was asked
-   */
-  description?: string;
-  /**
-   * Outcome of the question that was asked
-   */
-  outcome?: "P" | "DF" | "S" | "D";
 }
 /**
  * This interface was referenced by `PartialTestResultCatDESchema`'s JSON-Schema

--- a/mes-test-schema/categories/F/index.json
+++ b/mes-test-schema/categories/F/index.json
@@ -565,19 +565,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/G/index.json
+++ b/mes-test-schema/categories/G/index.json
@@ -565,19 +565,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/H/index.json
+++ b/mes-test-schema/categories/H/index.json
@@ -565,19 +565,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/K/index.json
+++ b/mes-test-schema/categories/K/index.json
@@ -562,19 +562,6 @@
 				}
 			}
 		},
-		"safetyQuestionResult": {
-			"description": "Result of a safety question",
-			"type": "object",
-			"additionalProperties": false,
-			"properties": {
-				"description": {
-					"$ref": "#/definitions/questionDescription"
-				},
-				"outcome": {
-					"$ref": "#/definitions/questionOutcome"
-				}
-			}
-		},
 		"manoeuvreIndicator": {
 			"description": "Indicator for a manoeuvre being performed during the test",
 			"type": "boolean"

--- a/mes-test-schema/categories/common/index.d.ts
+++ b/mes-test-schema/categories/common/index.d.ts
@@ -1103,13 +1103,3 @@ export interface QuestionResult {
   description?: QuestionDescription;
   outcome?: QuestionOutcome;
 }
-/**
- * Result of a safety question
- *
- * This interface was referenced by `TestResultCommonSchema`'s JSON-Schema
- * via the `definition` "safetyQuestionResult".
- */
-export interface SafetyQuestionResult {
-  description?: QuestionDescription;
-  outcome?: QuestionOutcome;
-}

--- a/mes-test-schema/categories/common/index.json
+++ b/mes-test-schema/categories/common/index.json
@@ -540,19 +540,6 @@
         }
       }
     },
-    "safetyQuestionResult": {
-      "description": "Result of a safety question",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "$ref": "#/definitions/questionDescription"
-        },
-        "outcome": {
-          "$ref": "#/definitions/questionOutcome"
-        }
-      }
-    },
     "manoeuvreIndicator": {
       "description": "Indicator for a manoeuvre being performed during the test",
       "type": "boolean"

--- a/mes-test-schema/category-definitions/D/partial.json
+++ b/mes-test-schema/category-definitions/D/partial.json
@@ -94,22 +94,6 @@
       },
       "type": "object"
     },
-    "safetyQuestions": {
-      "additionalProperties": false,
-      "description": "Details of the safety questions asked during the test",
-      "properties": {
-        "questions": {
-          "items": {
-            "$ref": "#/definitions/safetyQuestionResult"
-          },
-          "type": "array"
-        },
-        "faultComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "type": "object"
-    },
     "vehicleDetails": {
       "additionalProperties": false,
       "type": "object",
@@ -178,9 +162,6 @@
         },
         "pcvDoorExercise": {
           "$ref": "#/definitions/pcvDoorExercise"
-        },
-        "safetyQuestions": {
-          "$ref": "#/definitions/safetyQuestions"
         }
       },
       "additionalProperties": false

--- a/mes-test-schema/category-definitions/D/partial.json
+++ b/mes-test-schema/category-definitions/D/partial.json
@@ -65,9 +65,6 @@
     "questionResult": {
       "$ref": "../common/index.json#/definitions/questionResult"
     },
-    "safetyQuestionResult": {
-      "$ref": "../common/index.json#/definitions/safetyQuestionResult"
-    },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",

--- a/mes-test-schema/category-definitions/D1/partial.json
+++ b/mes-test-schema/category-definitions/D1/partial.json
@@ -86,22 +86,6 @@
       },
       "type": "object"
     },
-    "safetyQuestions": {
-      "additionalProperties": false,
-      "description": "Details of the safety questions asked during the test",
-      "properties": {
-        "questions": {
-          "items": {
-            "$ref": "#/definitions/safetyQuestionResult"
-          },
-          "type": "array"
-        },
-        "faultComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "type": "object"
-    },
     "vehicleDetails": {
       "additionalProperties": false,
       "type": "object",
@@ -170,9 +154,6 @@
         },
         "pcvDoorExercise": {
           "$ref": "#/definitions/pcvDoorExercise"
-        },
-        "safetyQuestions": {
-          "$ref": "#/definitions/safetyQuestions"
         }
       },
       "additionalProperties": false

--- a/mes-test-schema/category-definitions/D1/partial.json
+++ b/mes-test-schema/category-definitions/D1/partial.json
@@ -57,9 +57,6 @@
     "questionResult": {
       "$ref": "../common/index.json#/definitions/questionResult"
     },
-    "safetyQuestionResult": {
-      "$ref": "../common/index.json#/definitions/safetyQuestionResult"
-    },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",

--- a/mes-test-schema/category-definitions/D1E/partial.json
+++ b/mes-test-schema/category-definitions/D1E/partial.json
@@ -72,9 +72,6 @@
     "questionResult": {
       "$ref": "../common/index.json#/definitions/questionResult"
     },
-    "safetyQuestionResult": {
-      "$ref": "../common/index.json#/definitions/safetyQuestionResult"
-    },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",

--- a/mes-test-schema/category-definitions/D1E/partial.json
+++ b/mes-test-schema/category-definitions/D1E/partial.json
@@ -101,22 +101,6 @@
       },
       "type": "object"
     },
-    "safetyQuestions": {
-      "additionalProperties": false,
-      "description": "Details of the safety questions asked during the test",
-      "properties": {
-        "questions": {
-          "items": {
-            "$ref": "#/definitions/safetyQuestionResult"
-          },
-          "type": "array"
-        },
-        "faultComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "type": "object"
-    },
     "vehicleDetails": {
       "additionalProperties": false,
       "type": "object",
@@ -185,9 +169,6 @@
         },
         "pcvDoorExercise": {
           "$ref": "#/definitions/pcvDoorExercise"
-        },
-        "safetyQuestions": {
-          "$ref": "#/definitions/safetyQuestions"
         },
         "uncoupleRecouple": {
           "$ref": "#/definitions/uncoupleRecouple"

--- a/mes-test-schema/category-definitions/DE/partial.json
+++ b/mes-test-schema/category-definitions/DE/partial.json
@@ -109,22 +109,6 @@
       },
       "type": "object"
     },
-    "safetyQuestions": {
-      "additionalProperties": false,
-      "description": "Details of the safety questions asked during the test",
-      "properties": {
-        "questions": {
-          "items": {
-            "$ref": "#/definitions/safetyQuestionResult"
-          },
-          "type": "array"
-        },
-        "faultComments": {
-          "$ref": "#/definitions/faultComments"
-        }
-      },
-      "type": "object"
-    },
     "vehicleDetails": {
       "additionalProperties": false,
       "type": "object",
@@ -193,9 +177,6 @@
         },
         "pcvDoorExercise": {
           "$ref": "#/definitions/pcvDoorExercise"
-        },
-        "safetyQuestions": {
-          "$ref": "#/definitions/safetyQuestions"
         },
         "uncoupleRecouple": {
           "$ref": "#/definitions/uncoupleRecouple"

--- a/mes-test-schema/category-definitions/DE/partial.json
+++ b/mes-test-schema/category-definitions/DE/partial.json
@@ -80,9 +80,6 @@
     "questionResult": {
       "$ref": "../common/index.json#/definitions/questionResult"
     },
-    "safetyQuestionResult": {
-      "$ref": "../common/index.json#/definitions/safetyQuestionResult"
-    },
     "vehicleChecks": {
       "additionalProperties": false,
       "description": "Details of the Show Me and Tell Me questions asked during the test",

--- a/mes-test-schema/category-definitions/common/index.json
+++ b/mes-test-schema/category-definitions/common/index.json
@@ -540,19 +540,6 @@
         }
       }
     },
-    "safetyQuestionResult": {
-      "description": "Result of a safety question",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "$ref": "#/definitions/questionDescription"
-        },
-        "outcome": {
-          "$ref": "#/definitions/questionOutcome"
-        }
-      }
-    },
     "manoeuvreIndicator": {
       "description": "Indicator for a manoeuvre being performed during the test",
       "type": "boolean"

--- a/mes-test-schema/package-lock.json
+++ b/mes-test-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mes-test-schema/package.json
+++ b/mes-test-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/mes-test-schema",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "description": "Domain model for data associated with tests administered by the Mobile Examiners Service",
   "scripts": {
     "generate": "ts-node generateSchemas.ts generate",


### PR DESCRIPTION
# Description and relevant Jira numbers

Removing safetyQuestions
Removing safetyQuestionResult

from cat D, D1, DE, D1E and common

Bumping version number.

> Not entirely sure why does GitHub recognise `mes-test-schema/categories/ADI2` and `mes-test-schema/categories/CPC` that the entire file changed. In reality only a few lines changed in both files. Here are some screenshots of VSCode to demonstrate it:
> ![Screenshot 2020-11-24 at 15 37 49](https://user-images.githubusercontent.com/7311745/100119874-43486e80-2e6f-11eb-9cfe-1cebdd6d6802.png)
> ![Screenshot 2020-11-24 at 15 38 31](https://user-images.githubusercontent.com/7311745/100120008-6410c400-2e6f-11eb-8e20-b943b6ace0d0.png)

