### PR TITLE
MES-7513-Schema change to accomodate manoeuvre pass certificate number

### DIFF
--- a/mes-test-schema/categories/C/index.json
+++ b/mes-test-schema/categories/C/index.json
@@ -483,6 +483,12 @@
 				"candidateDeclarationSigned": {
 					"description": "Whether or not the candidate signature had been recorded for delegated tests",
 					"type": "boolean"
+				},
+				"manoeuvrePassCertificateNumber": {
+					"description": "Pass certificate number from the `a` part of the vocational test",
+					"type": "string",
+					"minLength": 8,
+					"maxLength": 8
 				}
 			},
 			"required": [

--- a/mes-test-schema/categories/C/partial.d.ts
+++ b/mes-test-schema/categories/C/partial.d.ts
@@ -214,3 +214,13 @@ export interface VehicleDetails {
 export interface PassCompletion {
   code78Present?: Code78Present;
 }
+/**
+ * This interface was referenced by `PartialTestResultCatCSchema`'s JSON-Schema
+ * via the `definition` "preTestDeclarations".
+ */
+export interface PreTestDeclarations {
+  /**
+   * Pass certificate number from the `a` part of the vocational test
+   */
+  manoeuvrePassCertificateNumber?: string;
+}

--- a/mes-test-schema/categories/C1/index.json
+++ b/mes-test-schema/categories/C1/index.json
@@ -483,6 +483,12 @@
 				"candidateDeclarationSigned": {
 					"description": "Whether or not the candidate signature had been recorded for delegated tests",
 					"type": "boolean"
+				},
+				"manoeuvrePassCertificateNumber": {
+					"description": "Pass certificate number from the `a` part of the vocational test",
+					"type": "string",
+					"minLength": 8,
+					"maxLength": 8
 				}
 			},
 			"required": [

--- a/mes-test-schema/categories/C1/partial.d.ts
+++ b/mes-test-schema/categories/C1/partial.d.ts
@@ -200,3 +200,13 @@ export interface VehicleDetails {
    */
   vehicleWidth?: number;
 }
+/**
+ * This interface was referenced by `PartialTestResultCatC1Schema`'s JSON-Schema
+ * via the `definition` "preTestDeclarations".
+ */
+export interface PreTestDeclarations {
+  /**
+   * Pass certificate number from the `a` part of the vocational test
+   */
+  manoeuvrePassCertificateNumber?: string;
+}

--- a/mes-test-schema/categories/C1E/index.json
+++ b/mes-test-schema/categories/C1E/index.json
@@ -486,6 +486,12 @@
 				"candidateDeclarationSigned": {
 					"description": "Whether or not the candidate signature had been recorded for delegated tests",
 					"type": "boolean"
+				},
+				"manoeuvrePassCertificateNumber": {
+					"description": "Pass certificate number from the `a` part of the vocational test",
+					"type": "string",
+					"minLength": 8,
+					"maxLength": 8
 				}
 			},
 			"required": [

--- a/mes-test-schema/categories/C1E/partial.d.ts
+++ b/mes-test-schema/categories/C1E/partial.d.ts
@@ -210,3 +210,13 @@ export interface VehicleDetails {
    */
   vehicleWidth?: number;
 }
+/**
+ * This interface was referenced by `PartialTestResultCatC1ESchema`'s JSON-Schema
+ * via the `definition` "preTestDeclarations".
+ */
+export interface PreTestDeclarations {
+  /**
+   * Pass certificate number from the `a` part of the vocational test
+   */
+  manoeuvrePassCertificateNumber?: string;
+}

--- a/mes-test-schema/categories/CE/index.json
+++ b/mes-test-schema/categories/CE/index.json
@@ -486,6 +486,12 @@
 				"candidateDeclarationSigned": {
 					"description": "Whether or not the candidate signature had been recorded for delegated tests",
 					"type": "boolean"
+				},
+				"manoeuvrePassCertificateNumber": {
+					"description": "Pass certificate number from the `a` part of the vocational test",
+					"type": "string",
+					"minLength": 8,
+					"maxLength": 8
 				}
 			},
 			"required": [

--- a/mes-test-schema/categories/CE/partial.d.ts
+++ b/mes-test-schema/categories/CE/partial.d.ts
@@ -224,3 +224,13 @@ export interface VehicleDetails {
 export interface PassCompletion {
   code78Present?: Code78Present;
 }
+/**
+ * This interface was referenced by `PartialTestResultCatCESchema`'s JSON-Schema
+ * via the `definition` "preTestDeclarations".
+ */
+export interface PreTestDeclarations {
+  /**
+   * Pass certificate number from the `a` part of the vocational test
+   */
+  manoeuvrePassCertificateNumber?: string;
+}

--- a/mes-test-schema/category-definitions/C/partial.json
+++ b/mes-test-schema/category-definitions/C/partial.json
@@ -16,6 +16,18 @@
     "faultComments": {
       "$ref": "../common/index.json#/definitions/faultComments"
     },
+    "preTestDeclarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "manoeuvrePassCertificateNumber": {
+          "description": "Pass certificate number from the `a` part of the vocational test",
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
     "manoeuvre": {
       "$ref": "../common/index.json#/definitions/manoeuvre"
     },

--- a/mes-test-schema/category-definitions/C1/partial.json
+++ b/mes-test-schema/category-definitions/C1/partial.json
@@ -5,6 +5,18 @@
     "faultComments": {
       "$ref": "../common/index.json#/definitions/faultComments"
     },
+    "preTestDeclarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "manoeuvrePassCertificateNumber": {
+          "description": "Pass certificate number from the `a` part of the vocational test",
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
     "manoeuvre": {
       "$ref": "../common/index.json#/definitions/manoeuvre"
     },

--- a/mes-test-schema/category-definitions/C1E/partial.json
+++ b/mes-test-schema/category-definitions/C1E/partial.json
@@ -20,6 +20,18 @@
     "faultComments": {
       "$ref": "../common/index.json#/definitions/faultComments"
     },
+    "preTestDeclarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "manoeuvrePassCertificateNumber": {
+          "description": "Pass certificate number from the `a` part of the vocational test",
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
     "manoeuvre": {
       "$ref": "../common/index.json#/definitions/manoeuvre"
     },

--- a/mes-test-schema/category-definitions/CE/partial.json
+++ b/mes-test-schema/category-definitions/CE/partial.json
@@ -31,6 +31,18 @@
     "faultComments": {
       "$ref": "../common/index.json#/definitions/faultComments"
     },
+    "preTestDeclarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "manoeuvrePassCertificateNumber": {
+          "description": "Pass certificate number from the `a` part of the vocational test",
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 8
+        }
+      }
+    },
     "manoeuvre": {
       "$ref": "../common/index.json#/definitions/manoeuvre"
     },


### PR DESCRIPTION

# Description and relevant Jira numbers

added manoeuvrePassCertificateNumber to the preTestDelcatation to all cat C (Part B) tests as an optional string of length 8

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA